### PR TITLE
Persist allocations, make room for "null" allocation inside a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- persist allocations in cookie, we want it stable even if config changes
+- improve the data driven SDK compatibility test suite
+### Changed
+- move cookie handling out from visitor module, needed for allocations as well
+- total weight is always 100, allows for projects without full allocation
+- don't allocate if project is inactive
+
 ## [0.1.0] - 2022-05-12
 ### Added
 - A first version of the SDK

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,9 @@ act -P ubuntu-latest=shivammathur/node:latest
 1. create a new branch for your changes
 1. write code and tests
 1. add the change to [the changelog](./CHANGELOG.md) under "Unreleased"
+1. consider if your change requires a major, minor or patch version change
+   (compared to the latest release before "Unreleased" in the changelog) and
+   update the "-dev" version in package.json accordingly
 1. get the pull request reviewed and approved
 1. squash merge the changes to `main`
 1. delete the branch that was merged

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@symplify-conversion/sst-sdk-nodejs",
-  "version": "0.1.1-dev",
+  "version": "0.2.0-dev",
   "description": "This is the Node.js implementation of the Symplify Server-Side Testing SDK.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -103,7 +103,7 @@ export class SymplifySDK {
             return null;
         }
 
-        if (project.state != "active") {
+        if (project.state !== "active") {
             return null;
         }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -115,6 +115,7 @@ export class SymplifySDK {
             return null;
         }
 
+        siteData.rememberAllocation(project, variation);
         siteData.save(cookies);
 
         return variation.name;

--- a/src/client.ts
+++ b/src/client.ts
@@ -103,6 +103,11 @@ export class SymplifySDK {
             return null;
         }
 
+        const currAllocation = siteData.getAllocation(project);
+        if (currAllocation != null) {
+            return currAllocation.name;
+        }
+
         const visID = ensureVisitorID(siteData, this.idGenerator);
         if (!visID) {
             this.log.error("could not get or generate a visitor ID");

--- a/src/client.ts
+++ b/src/client.ts
@@ -104,8 +104,17 @@ export class SymplifySDK {
         }
 
         const currAllocation = siteData.getAllocation(project);
-        if (currAllocation != null) {
-            return currAllocation.name;
+
+        switch (currAllocation) {
+            case undefined:
+                // no allocation data
+                break;
+            case null:
+                // explicit null allocation
+                return null;
+            default:
+                // variation allocation
+                return currAllocation.name;
         }
 
         const visID = ensureVisitorID(siteData, this.idGenerator);
@@ -116,14 +125,15 @@ export class SymplifySDK {
 
         const variation = findVariationForVisitor(project, visID);
 
-        if (!variation) {
-            return null;
+        if (variation) {
+            siteData.rememberAllocation(project, variation);
+        } else {
+            siteData.rememberNullAllocation(project);
         }
 
-        siteData.rememberAllocation(project, variation);
         siteData.save(cookies);
 
-        return variation.name;
+        return variation ? variation.name : null;
     }
 
     configURL(): string {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { CookieJar } from "./cookies";
+import { CookieJar, WebsiteData } from "./cookies";
 import { httpsGET } from "./http";
 import { Logger, NullLogger } from "./logger";
 import {
@@ -91,13 +91,19 @@ export class SymplifySDK {
             return null;
         }
 
+        const siteData = new WebsiteData(this.websiteID, cookies);
+        if (!siteData.isCompatible()) {
+            this.log.warn("findVariation: unsupported cookie generation");
+            return null;
+        }
+
         const project = findProjectWithName(this.config.latest, projectName);
         if (!project) {
             this.log.error(`findVariation: unknown project: ${projectName}`);
             return null;
         }
 
-        const visID = ensureVisitorID(cookies.get, cookies.set, this.websiteID, this.idGenerator);
+        const visID = ensureVisitorID(siteData, this.idGenerator);
         if (!visID) {
             this.log.error("could not get or generate a visitor ID");
             return null;
@@ -108,6 +114,8 @@ export class SymplifySDK {
         if (!variation) {
             return null;
         }
+
+        siteData.save(cookies);
 
         return variation.name;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -103,6 +103,10 @@ export class SymplifySDK {
             return null;
         }
 
+        if (project.state != "active") {
+            return null;
+        }
+
         const currAllocation = siteData.getAllocation(project);
 
         switch (currAllocation) {

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -76,6 +76,10 @@ export class WebsiteData {
         this.set(project.id + "", [variation.id]);
     }
 
+    rememberNullAllocation(project: ProjectConfig): void {
+        this.set(project.id + "_ch", -1);
+    }
+
     getAllocation(project: ProjectConfig): VariationConfig | null {
         if (this.get(project.id + "_ch") != 1) {
             return null;

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -76,6 +76,25 @@ export class WebsiteData {
         this.set(project.id + "", [variation.id]);
     }
 
+    getAllocation(project: ProjectConfig): VariationConfig | null {
+        if (this.get(project.id + "_ch") != 1) {
+            return null;
+        }
+
+        const allocatedVariations = this.get(project.id + "");
+        if (!Array.isArray(allocatedVariations)) {
+            return null;
+        }
+
+        for (const variation of project.variations) {
+            if (variation.id == allocatedVariations[0]) {
+                return variation;
+            }
+        }
+
+        return null;
+    }
+
     private get(key: string): unknown {
         if (!this.isCompatible()) {
             return null;

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,3 +1,5 @@
+import { ProjectConfig, VariationConfig } from "./project";
+
 export type CookieJar = {
     get: (name: string) => string;
     set: (name: string, value: string) => void;
@@ -59,16 +61,32 @@ export class WebsiteData {
     }
 
     getVisitorID(): string | null {
-        if (!this.isCompatible()) {
-            return null;
-        }
-        return this.jsonCookie[this.websiteID][JSON_COOKIE_VISITOR_ID_KEY];
+        const val = this.get(JSON_COOKIE_VISITOR_ID_KEY);
+        return typeof val == "string" ? val : null;
     }
 
     setVisitorID(visitorID: string): void {
+        this.set(JSON_COOKIE_VISITOR_ID_KEY, visitorID);
+    }
+
+    rememberAllocation(project: ProjectConfig, variation: VariationConfig): void {
+        const prevAudP = this.get("aud_p");
+        this.set("aud_p", (Array.isArray(prevAudP) ? prevAudP : []).concat(project.id));
+        this.set(project.id + "_ch", 1);
+        this.set(project.id + "", [variation.id]);
+    }
+
+    private get(key: string): unknown {
+        if (!this.isCompatible()) {
+            return null;
+        }
+        return this.jsonCookie[this.websiteID][key];
+    }
+
+    private set(key: string, value: unknown): void {
         if (!this.isCompatible()) {
             return;
         }
-        this.jsonCookie[this.websiteID][JSON_COOKIE_VISITOR_ID_KEY] = visitorID;
+        this.jsonCookie[this.websiteID][key] = value;
     }
 }

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -80,14 +80,20 @@ export class WebsiteData {
         this.set(project.id + "_ch", -1);
     }
 
-    getAllocation(project: ProjectConfig): VariationConfig | null {
-        if (this.get(project.id + "_ch") != 1) {
+    /**
+     * Get current allocation info from the website data.
+     *
+     * @param project check existing allocation for this project
+     * @returns the allocated variation if it exists, null if a null allocation exists, undefined if there is no info
+     */
+    getAllocation(project: ProjectConfig): VariationConfig | undefined | null {
+        if (this.get(project.id + "_ch") == -1) {
             return null;
         }
 
         const allocatedVariations = this.get(project.id + "");
         if (!Array.isArray(allocatedVariations)) {
-            return null;
+            return undefined;
         }
 
         for (const variation of project.variations) {
@@ -96,7 +102,7 @@ export class WebsiteData {
             }
         }
 
-        return null;
+        return undefined;
     }
 
     private get(key: string): unknown {

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -22,3 +22,53 @@ export class JSONCookieCodec {
         this.underlying.set(name, encodeURIComponent(JSON.stringify(value)));
     }
 }
+
+const JSON_COOKIE_NAME = "sg_cookies";
+const JSON_COOKIE_VERSION_KEY = "_g";
+const JSON_COOKIE_VISITOR_ID_KEY = "visid";
+const SUPPORTED_JSON_COOKIE_VERSION = 1;
+
+/**
+ * WebsiteData is a cookie persistence layer compatible with the frontend js-sdk.
+ * It helps us keep the visitor ID stable, and remember variation allocations when
+ * project configs change.
+ */
+export class WebsiteData {
+    websiteID: string;
+    // the underlying value is an object with quite dynamic attributes
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jsonCookie: any;
+
+    constructor(websiteID: string, cookies: CookieJar) {
+        const existing = new JSONCookieCodec(cookies).get(JSON_COOKIE_NAME);
+        const jsonCookie = existing || { [JSON_COOKIE_VERSION_KEY]: SUPPORTED_JSON_COOKIE_VERSION };
+
+        if (!jsonCookie[websiteID]) {
+            jsonCookie[websiteID] = {};
+        }
+        this.websiteID = websiteID;
+        this.jsonCookie = jsonCookie;
+    }
+
+    save(cookies: CookieJar): void {
+        new JSONCookieCodec(cookies).set(JSON_COOKIE_NAME, this.jsonCookie);
+    }
+
+    isCompatible(): boolean {
+        return this.jsonCookie[JSON_COOKIE_VERSION_KEY] === SUPPORTED_JSON_COOKIE_VERSION;
+    }
+
+    getVisitorID(): string | null {
+        if (!this.isCompatible()) {
+            return null;
+        }
+        return this.jsonCookie[this.websiteID][JSON_COOKIE_VISITOR_ID_KEY];
+    }
+
+    setVisitorID(visitorID: string): void {
+        if (!this.isCompatible()) {
+            return;
+        }
+        this.jsonCookie[this.websiteID][JSON_COOKIE_VISITOR_ID_KEY] = visitorID;
+    }
+}

--- a/src/project.ts
+++ b/src/project.ts
@@ -39,7 +39,7 @@ export function findVariationForVisitor(
     project: ProjectConfig,
     visitorID: string,
 ): VariationConfig | null {
-    if (!visitorID || project.state != "active") {
+    if (!visitorID || project.state !== "active") {
         return null;
     }
 
@@ -54,7 +54,7 @@ export function findVariationForVisitor(
     for (const variation of project.variations) {
         pointer += variation.weight;
         if (hash <= pointer) {
-            return variation.state == "active" ? variation : null;
+            return variation.state === "active" ? variation : null;
         }
     }
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -43,10 +43,7 @@ export function findVariationForVisitor(
         return null;
     }
 
-    let totalWeight = 0;
-    for (const variation of project.variations) {
-        totalWeight += variation.weight;
-    }
+    const totalWeight = 100;
 
     const hashKey = `${visitorID}:${project.id}`;
     let hash = djb2(hashKey);

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -1,47 +1,22 @@
 import { randomUUID } from "crypto";
-import { JSONCookieCodec } from "./cookies";
-
-const JSON_COOKIE_NAME = "sg_cookies";
-const JSON_COOKIE_VERSION_KEY = "_g";
-const JSON_COOKIE_VISITOR_ID_KEY = "visid";
-const SUPPORTED_JSON_COOKIE_VERSION = 1;
+import { WebsiteData } from "./cookies";
 
 /**
  * Gets the visitor ID from our cookie, if uninitialized, create one and update
  * the cookie. This keeps visitor IDs in sync with frontend logic.
  *
- * @param getCookie get a cookie by name from the current request
- * @param setCookie set a cookie by name in the current response
- * @param websiteID the ID of the website (needed for cookie compatibility)
+ * @param websiteData manages persistence
  * @param idGenerator used to generate a new ID if needed (in a uniformly random distribution)
  * @returns null if no visitor ID could be assigned, otherwise the assigned visitor ID
  */
 export function ensureVisitorID(
-    getCookie: (name: string) => string,
-    setCookie: (name: string, value: string) => void,
-    websiteID: string,
+    websiteData: WebsiteData,
     idGenerator: () => string = randomUUID,
 ): string | null {
-    const cookies = new JSONCookieCodec({ get: getCookie, set: setCookie });
-
-    const existingCookie = cookies.get(JSON_COOKIE_NAME);
-    const sgCookies = existingCookie || {
-        [JSON_COOKIE_VERSION_KEY]: SUPPORTED_JSON_COOKIE_VERSION,
-    };
-
-    if (sgCookies[JSON_COOKIE_VERSION_KEY] != SUPPORTED_JSON_COOKIE_VERSION) {
-        return null;
-    }
-
-    if (!sgCookies[websiteID]) {
-        sgCookies[websiteID] = {};
-    }
-
-    let vid = sgCookies[websiteID][JSON_COOKIE_VISITOR_ID_KEY];
+    let vid = websiteData.getVisitorID();
     if (!vid) {
         vid = idGenerator();
-        sgCookies[websiteID][JSON_COOKIE_VISITOR_ID_KEY] = vid;
-        cookies.set(JSON_COOKIE_NAME, sgCookies);
+        websiteData.setVisitorID(vid);
     }
 
     return vid;

--- a/test/allocation.test.ts
+++ b/test/allocation.test.ts
@@ -5,18 +5,8 @@ const TEST_PROJECT: ProjectConfig = {
     name: "discount",
     state: "active",
     variations: [
-        {
-            id: 42,
-            name: "original",
-            state: "active",
-            weight: 2,
-        },
-        {
-            id: 1337,
-            name: "massive",
-            state: "active",
-            weight: 1,
-        },
+        { id: 42, name: "original", state: "active", weight: 67 },
+        { id: 1337, name: "massive", state: "active", weight: 33 },
     ],
 };
 
@@ -42,18 +32,8 @@ describe("Variation allocation", () => {
             name: "test project",
             state: "active",
             variations: [
-                {
-                    id: originalID,
-                    name: "Original",
-                    state: "active",
-                    weight: 1,
-                },
-                {
-                    id: variationID,
-                    name: "Variation",
-                    state: "active",
-                    weight: 1000,
-                },
+                { id: originalID, name: "Original", state: "active", weight: 50 },
+                { id: variationID, name: "Variation", state: "active", weight: 50 },
             ],
         };
 
@@ -66,5 +46,30 @@ describe("Variation allocation", () => {
         const visid = "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
         const variation = findVariationForVisitor(TEST_PROJECT, visid) || sentinelVariation;
         expect(variation.id).toBe(1337);
+    });
+
+    test("handles empty allocations", () => {
+        const testProject: ProjectConfig = {
+            id: 4711,
+            name: "discount",
+            state: "active",
+            variations: [
+                { id: 42, name: "original", state: "active", weight: 25 },
+                { id: 1337, name: "massive", state: "paused", weight: 25 },
+                { id: 11111, name: "extra", state: "active", weight: 25 },
+            ],
+        };
+        function findVariation(visid: string) {
+            return findVariationForVisitor(testProject, visid) || sentinelVariation;
+        }
+
+        // "aosidb" maps to 01-25, which is active variation 42
+        expect(findVariation("aosidb").id).toBe(42);
+        // "banana" maps to 26-50, which is paused variation 1337
+        expect(findVariation("banana").id).toBe(sentinelVariation.id);
+        // "visitor" maps to 51-75, which is active variation 11111
+        expect(findVariation("visitor").id).toBe(11111);
+        // "asidub" maps to 75-100, which is outside any variation
+        expect(findVariation("asidub").id).toBe(sentinelVariation.id);
     });
 });

--- a/test/allocation.test.ts
+++ b/test/allocation.test.ts
@@ -72,4 +72,18 @@ describe("Variation allocation", () => {
         // "asidub" maps to 75-100, which is outside any variation
         expect(findVariation("asidub").id).toBe(sentinelVariation.id);
     });
+
+    test("doesn't allocate in paused projects", () => {
+        const testProject: ProjectConfig = {
+            id: 4711,
+            name: "discount",
+            state: "paused",
+            variations: [
+                { id: 42, name: "original", state: "active", weight: 25 },
+                { id: 1337, name: "massive", state: "paused", weight: 25 },
+                { id: 11111, name: "extra", state: "active", weight: 25 },
+            ],
+        };
+        expect(findVariationForVisitor(testProject, "anyone")).toBe(null);
+    });
 });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -26,7 +26,7 @@ describe("SymplifySDK client", () => {
             for (const [keypath, regex] of Object.entries(t.expect_sg_cookie_properties_match)) {
                 const reCookie = new RegExp(regex as string);
                 const leaf = keypath.split("/").reduce((acc, p) => (acc || {})[p], sgCookies);
-                expect(leaf || "null").toMatch(reCookie);
+                expect("" + (leaf || "null")).toMatch(reCookie);
             }
 
             const reVariation = new RegExp(t.expect_variation_match);

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -21,9 +21,13 @@ describe("SymplifySDK client", () => {
             const variation = sdk.findVariation(t.test_project_name, cookies);
             sdk.stop();
 
-            const reCookie = new RegExp(t.expect_cookie_match);
+            const sgCookies = JSON.parse(decodeURIComponent(cookies.get("sg_cookies") || "{}"));
 
-            expect(cookies.get("sg_cookies") || "null").toMatch(reCookie);
+            for (const [keypath, regex] of Object.entries(t.expect_sg_cookie_properties_match)) {
+                const reCookie = new RegExp(regex as string);
+                const leaf = keypath.split("/").reduce((acc, p) => (acc || {})[p], sgCookies);
+                expect(leaf || "null").toMatch(reCookie);
+            }
 
             const reVariation = new RegExp(t.expect_variation_match);
             expect(variation || "null").toMatch(reVariation);

--- a/test/cookies.test.ts
+++ b/test/cookies.test.ts
@@ -23,6 +23,14 @@ describe("WebsiteData", () => {
         expect(data.getAllocation(testProject)).toStrictEqual(testVar);
     });
 
+    test("can remember null allocations", () => {
+        const active: ProjectState = "active";
+        const testProject = { id: 1337, name: "project", variations: [], state: active };
+        const data = new WebsiteData("4711", makeCookieJar());
+        data.rememberNullAllocation(testProject);
+        expect(data.getAllocation(testProject)).toBe(null);
+    });
+
     test("can save by setting cookie", () => {
         const active: ProjectState = "active";
         const testVar = { id: 42, name: "a variation", state: active, weight: 100 };

--- a/test/cookies.test.ts
+++ b/test/cookies.test.ts
@@ -1,0 +1,45 @@
+import { WebsiteData } from "../src/cookies";
+import { ProjectState } from "../src/project";
+import { makeCookieJar } from "./helpers";
+
+describe("WebsiteData", () => {
+    test("can create fresh cookie data", () => {
+        const data = new WebsiteData("4711", makeCookieJar());
+        expect(data.isCompatible()).toBe(true);
+    });
+
+    test("can set and get visitor ID", () => {
+        const data = new WebsiteData("4711", makeCookieJar());
+        data.setVisitorID("foobar");
+        expect(data.getVisitorID()).toBe("foobar");
+    });
+
+    test("can set and get allocation info", () => {
+        const active: ProjectState = "active";
+        const testVar = { id: 42, name: "a variation", state: active, weight: 100 };
+        const testProject = { id: 1337, name: "project", variations: [testVar], state: active };
+        const data = new WebsiteData("4711", makeCookieJar());
+        data.rememberAllocation(testProject, testVar);
+        expect(data.getAllocation(testProject)).toStrictEqual(testVar);
+    });
+
+    test("can save by setting cookie", () => {
+        const active: ProjectState = "active";
+        const testVar = { id: 42, name: "a variation", state: active, weight: 100 };
+        const testProject = { id: 1337, name: "project", variations: [testVar], state: active };
+        const cookies = makeCookieJar();
+        const data = new WebsiteData("4711", cookies);
+        data.setVisitorID("goober");
+        data.rememberAllocation(testProject, testVar);
+        data.save(cookies);
+        expect(JSON.parse(decodeURIComponent(cookies.get("sg_cookies")))).toStrictEqual({
+            "4711": {
+                "1337": [42],
+                "1337_ch": 1,
+                aud_p: [1337],
+                visid: "goober",
+            },
+            _g: 1,
+        });
+    });
+});

--- a/test/sdk_config.json
+++ b/test/sdk_config.json
@@ -21,6 +21,15 @@
         { "id": 10022, "name": "Variation 1", "weight": 50, "state": "active" }
       ],
       "state": "active"
+    },
+    {
+      "id": 1003,
+      "name": "no allocations",
+      "variations": [
+        { "id": 10031, "name": "Original", "weight": 0, "state": "active" },
+        { "id": 10032, "name": "Variation 1", "weight": 0, "state": "paused" }
+      ],
+      "state": "active"
     }
   ]
 }

--- a/test/sdk_config.json
+++ b/test/sdk_config.json
@@ -8,8 +8,7 @@
       "variations": [
         { "id": 10011, "name": "Original", "weight": 25, "state": "active" },
         { "id": 10012, "name": "paused variation 1", "weight": 25, "state": "paused" },
-        { "id": 10013, "name": "active variation 2", "weight": 25, "state": "active" },
-        { "id": 10014, "name": "active variation 3", "weight": 25, "state": "active" }
+        { "id": 10013, "name": "active variation 2", "weight": 25, "state": "active" }
       ],
       "state": "active"
     },

--- a/test/sdk_config.json
+++ b/test/sdk_config.json
@@ -29,6 +29,15 @@
         { "id": 10032, "name": "Variation 1", "weight": 0, "state": "paused" }
       ],
       "state": "active"
+    },
+    {
+      "id": 1004,
+      "name": "paused project",
+      "variations": [
+        { "id": 10041, "name": "Original", "weight": 0, "state": "active" },
+        { "id": 10042, "name": "Variation 1", "weight": 0, "state": "paused" }
+      ],
+      "state": "paused"
     }
   ]
 }

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -98,5 +98,25 @@
     "test_project_name": "no allocations",
     "expect_variation_match": "Variation 1",
     "expect_sg_cookie_properties_match": {}
+  },
+  {
+    "test_name": "persist null allocation",
+    "sdk_config": "sdk_config.json",
+    "website_id": "10001",
+    "sg_cookies": null,
+    "test_project_name": "no allocations",
+    "expect_variation_match": null,
+    "expect_sg_cookie_properties_match": {
+      "10001/1003_ch": "-1"
+    }
+  },
+  {
+    "test_name": "reuse null allocation after config change",
+    "sdk_config": "sdk_config.json",
+    "website_id": "10001",
+    "sg_cookies": "{%2210001%22:{%221001_ch%22:-1%2C%22visid%22:%22goober%22}%2C%22_g%22:1}",
+    "test_project_name": "test project",
+    "expect_variation_match": null,
+    "expect_sg_cookie_properties_match": {}
   }
 ]

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -6,7 +6,9 @@
     "sg_cookies": null,
     "test_project_name": "does not exist",
     "expect_variation_match": null,
-    "expect_cookie_match": null
+    "expect_sg_cookie_properties_match": {
+      "10001/visid": null
+    }
   },
   {
     "test_name": "no cookie generates ID, allocates any variation",
@@ -15,42 +17,52 @@
     "sg_cookies": null,
     "test_project_name": "all active",
     "expect_variation_match": "Original|Variation",
-    "expect_cookie_match": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    "expect_sg_cookie_properties_match": {
+      "10001/visid": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    }
   },
   {
-    "test_name": "hash is compatible",
+    "test_name": "hash is compatible 1",
     "sdk_config": "sdk_config.json",
     "website_id": "10001",
     "sg_cookies": "{%2210001%22:{%22visid%22:%22foobar%22%2C%22100000002%22:[300001]%2C%22100000001%22:[300002]%2C%22100000002_ch%22:1%2C%22100000001_ch%22:1%2C%22lv%22:1650967549303%2C%22rf%22:%22%22%2C%22pv%22:2%2C%22pv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22tv%22:2%2C%22tv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22aud_p%22:[100000002%2C100000001]}%2C%22_g%22:1}",
     "test_project_name": "test project",
     "expect_variation_match": "Original",
-    "expect_cookie_match": "foobar"
+    "expect_sg_cookie_properties_match": {
+      "10001/visid": "foobar"
+    }
   },
   {
-    "test_name": "hash is compatible",
+    "test_name": "hash is compatible 2",
     "sdk_config": "sdk_config.json",
     "website_id": "10001",
     "sg_cookies": "{%2210001%22:{%22visid%22:%22b7850777-f581-4f66-ad3e-4e54963661df%22%2C%22100000002%22:[300001]%2C%22100000001%22:[300002]%2C%22100000002_ch%22:1%2C%22100000001_ch%22:1%2C%22lv%22:1650967549303%2C%22rf%22:%22%22%2C%22pv%22:2%2C%22pv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22tv%22:2%2C%22tv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22aud_p%22:[100000002%2C100000001]}%2C%22_g%22:1}",
     "test_project_name": "test project",
     "expect_variation_match": "null",
-    "expect_cookie_match": "b7850777-f581-4f66-ad3e-4e54963661df"
+    "expect_sg_cookie_properties_match": {
+      "10001/visid": "b7850777-f581-4f66-ad3e-4e54963661df"
+    }
   },
   {
-    "test_name": "hash is compatible",
+    "test_name": "hash is compatible 3",
     "sdk_config": "sdk_config.json",
     "website_id": "10001",
     "sg_cookies": "{%2210001%22:{%22visid%22:%22Fabian%22%2C%22100000002%22:[300001]%2C%22100000001%22:[300002]%2C%22100000002_ch%22:1%2C%22100000001_ch%22:1%2C%22lv%22:1650967549303%2C%22rf%22:%22%22%2C%22pv%22:2%2C%22pv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22tv%22:2%2C%22tv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22aud_p%22:[100000002%2C100000001]}%2C%22_g%22:1}",
     "test_project_name": "test project",
     "expect_variation_match": "active variation 2",
-    "expect_cookie_match": "Fabian"
+    "expect_sg_cookie_properties_match": {
+      "10001/visid": "Fabian"
+    }
   },
   {
-    "test_name": "hash is compatible",
+    "test_name": "hash is compatible 4",
     "sdk_config": "sdk_config.json",
     "website_id": "10001",
     "sg_cookies": "{%2210001%22:{%22visid%22:%22goober%22%2C%22100000002%22:[300001]%2C%22100000001%22:[300002]%2C%22100000002_ch%22:1%2C%22100000001_ch%22:1%2C%22lv%22:1650967549303%2C%22rf%22:%22%22%2C%22pv%22:2%2C%22pv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22tv%22:2%2C%22tv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22aud_p%22:[100000002%2C100000001]}%2C%22_g%22:1}",
     "test_project_name": "test project",
     "expect_variation_match": "active variation 3",
-    "expect_cookie_match": "goober"
+    "expect_sg_cookie_properties_match": {
+      "10001/visid": "goober"
+    }
   }
 ]

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -64,5 +64,17 @@
     "expect_sg_cookie_properties_match": {
       "10001/visid": "goober"
     }
+  },
+  {
+    "test_name": "incompatible cookie generation",
+    "sdk_config": "sdk_config.json",
+    "website_id": "10001",
+    "sg_cookies": "{%2210001%22:{%22visid%22:%22goober%22}%2C%22_g%22:1000000}",
+    "test_project_name": "test project",
+    "expect_variation_match": null,
+    "expect_sg_cookie_properties_match": {
+      "10001/visid": "goober",
+      "10001/aud_p": null
+    }
   }
 ]

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -89,5 +89,14 @@
       "10001/1001": "[10014]",
       "10001/aud_p": "[1001]"
     }
+  },
+  {
+    "test_name": "reuse previous allocation after config change",
+    "sdk_config": "sdk_config.json",
+    "website_id": "10001",
+    "sg_cookies": "{%2210001%22:{%221003%22:[10032]%2C%221003_ch%22:1%2C%22aud_p%22:[1003]%2C%22visid%22:%22a_visitor%22}%2C%22_g%22:1}",
+    "test_project_name": "no allocations",
+    "expect_variation_match": "Variation 1",
+    "expect_sg_cookie_properties_match": {}
   }
 ]

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -118,5 +118,14 @@
     "test_project_name": "test project",
     "expect_variation_match": null,
     "expect_sg_cookie_properties_match": {}
+  },
+  {
+    "test_name": "cookie allocated but inactive project",
+    "sdk_config": "sdk_config.json",
+    "website_id": "10001",
+    "sg_cookies": "{%2210001%22:{%221004%22:[10042]%2C%221004_ch%22:1%2C%22aud_p%22:[1004]%2C%22visid%22:%22a_visitor%22}%2C%22_g%22:1}",
+    "test_project_name": "paused project",
+    "expect_variation_match": null,
+    "expect_sg_cookie_properties_match": {}
   }
 ]

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -33,12 +33,12 @@
     }
   },
   {
-    "test_name": "hash is compatible 2",
+    "test_name": "hash is compatible 2, paused variation hit",
     "sdk_config": "sdk_config.json",
     "website_id": "10001",
     "sg_cookies": "{%2210001%22:{%22visid%22:%22b7850777-f581-4f66-ad3e-4e54963661df%22%2C%22100000002%22:[300001]%2C%22100000001%22:[300002]%2C%22100000002_ch%22:1%2C%22100000001_ch%22:1%2C%22lv%22:1650967549303%2C%22rf%22:%22%22%2C%22pv%22:2%2C%22pv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22tv%22:2%2C%22tv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22aud_p%22:[100000002%2C100000001]}%2C%22_g%22:1}",
     "test_project_name": "test project",
-    "expect_variation_match": "null",
+    "expect_variation_match": null,
     "expect_sg_cookie_properties_match": {
       "10001/visid": "b7850777-f581-4f66-ad3e-4e54963661df"
     }
@@ -55,12 +55,12 @@
     }
   },
   {
-    "test_name": "hash is compatible 4",
+    "test_name": "hash is compatible 4, no variation hit",
     "sdk_config": "sdk_config.json",
     "website_id": "10001",
     "sg_cookies": "{%2210001%22:{%22visid%22:%22goober%22%2C%22100000002%22:[300001]%2C%22100000001%22:[300002]%2C%22100000002_ch%22:1%2C%22100000001_ch%22:1%2C%22lv%22:1650967549303%2C%22rf%22:%22%22%2C%22pv%22:2%2C%22pv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22tv%22:2%2C%22tv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22aud_p%22:[100000002%2C100000001]}%2C%22_g%22:1}",
     "test_project_name": "test project",
-    "expect_variation_match": "active variation 3",
+    "expect_variation_match": null,
     "expect_sg_cookie_properties_match": {
       "10001/visid": "goober"
     }
@@ -81,12 +81,12 @@
     "test_name": "persist variation allocation",
     "sdk_config": "sdk_config.json",
     "website_id": "10001",
-    "sg_cookies": "{%2210001%22:{%22visid%22:%22goober%22}%2C%22_g%22:1}",
+    "sg_cookies": "{%2210001%22:{%22visid%22:%22Fabian%22}%2C%22_g%22:1}",
     "test_project_name": "test project",
-    "expect_variation_match": "active variation 3",
+    "expect_variation_match": "active variation 2",
     "expect_sg_cookie_properties_match": {
       "10001/1001_ch": "1",
-      "10001/1001": "[10014]",
+      "10001/1001": "[10013]",
       "10001/aud_p": "[1001]"
     }
   },

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -76,5 +76,18 @@
       "10001/visid": "goober",
       "10001/aud_p": null
     }
+  },
+  {
+    "test_name": "persist variation allocation",
+    "sdk_config": "sdk_config.json",
+    "website_id": "10001",
+    "sg_cookies": "{%2210001%22:{%22visid%22:%22goober%22}%2C%22_g%22:1}",
+    "test_project_name": "test project",
+    "expect_variation_match": "active variation 3",
+    "expect_sg_cookie_properties_match": {
+      "10001/1001_ch": "1",
+      "10001/1001": "[10014]",
+      "10001/aud_p": "[1001]"
+    }
   }
 ]

--- a/test/visitor.test.ts
+++ b/test/visitor.test.ts
@@ -1,74 +1,56 @@
 import crypto from "crypto";
+import { WebsiteData } from "../src/cookies";
 import { ensureVisitorID } from "../src/visitor";
 import { generateConstantID, makeCookieJar } from "./helpers";
 
 const JSON_COOKIE_NAME = "sg_cookies";
-const VISITOR_ID_COOKIE_KEY = "visid";
 
 describe("ensureVisitorID", () => {
-    test("can set our JSON cookie", () => {
+    test("can use the given ID generator", () => {
         const cookies = makeCookieJar();
         const testWebsiteID = "4711";
+        const siteData = new WebsiteData(testWebsiteID, cookies);
 
-        const returnedID = ensureVisitorID(
-            cookies.get,
-            cookies.set,
-            testWebsiteID,
-            generateConstantID("goober"),
-        );
-
-        const cookieObj = JSON.parse(decodeURIComponent(cookies.get(JSON_COOKIE_NAME)));
+        const returnedID = ensureVisitorID(siteData, generateConstantID("goober"));
 
         expect(returnedID).toBe("goober");
-        expect(cookieObj[testWebsiteID][VISITOR_ID_COOKIE_KEY]).toBe("goober");
     });
 
-    test("reuses values in our JSON cookie", () => {
+    test("can update sitedata", () => {
+        const cookies = makeCookieJar();
+        const testWebsiteID = "4711";
+        const siteData = new WebsiteData(testWebsiteID, cookies);
+
+        const returnedID = ensureVisitorID(siteData, generateConstantID("goober"));
+
+        expect(returnedID).toBe("goober");
+        expect(siteData.getVisitorID()).toBe("goober");
+    });
+
+    test("reuses values from sitedata", () => {
         const cookies = makeCookieJar();
         const testWebsiteID = "10001";
 
         // eslint-disable-next-line prettier/prettier
         const rawCookie = "{%2210001%22:{%22100000002%22:[300001]%2C%22100000001%22:[300002]%2C%22100000002_ch%22:1%2C%22100000001_ch%22:1%2C%22lv%22:1650967549303%2C%22rf%22:%22%22%2C%22pv%22:2%2C%22pv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22tv%22:2%2C%22tv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22aud_p%22:[100000002%2C100000001]%2C%22visid%22:%2278ac2972-de5f-4262-bfdb-7296eb132a94%22%2C%22commid%22:%221be9f08d-c36c-4bce-b157-e057e050027c%22}%2C%22_g%22:1}";
-        const cookieJSON = decodeURIComponent(rawCookie);
-        cookies.set(JSON_COOKIE_NAME, cookieJSON);
+        cookies.set(JSON_COOKIE_NAME, rawCookie);
+        const siteData = new WebsiteData(testWebsiteID, cookies);
 
-        const returnedID = ensureVisitorID(
-            cookies.get,
-            cookies.set,
-            testWebsiteID,
-            generateConstantID("goober"),
-        );
+        const returnedID = ensureVisitorID(siteData, generateConstantID("don't use this"));
 
         expect(returnedID).toBe("78ac2972-de5f-4262-bfdb-7296eb132a94");
     });
 
-    test("aborts on unknown cookie version", () => {
-        const cookies = makeCookieJar();
-        const testWebsiteID = "10001";
-
-        // eslint-disable-next-line prettier/prettier
-        const rawCookie = "{%2210001%22:{%22100000002%22:[300001]%2C%22100000001%22:[300002]%2C%22100000002_ch%22:1%2C%22100000001_ch%22:1%2C%22lv%22:1650967549303%2C%22rf%22:%22%22%2C%22pv%22:2%2C%22pv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22tv%22:2%2C%22tv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22aud_p%22:[100000002%2C100000001]%2C%22visid%22:%2278ac2972-de5f-4262-bfdb-7296eb132a94%22%2C%22commid%22:%221be9f08d-c36c-4bce-b157-e057e050027c%22}%2C%22_g%22:1000000}";
-        const cookieJSON = decodeURIComponent(rawCookie);
-        cookies.set(JSON_COOKIE_NAME, cookieJSON);
-
-        const returnedID = ensureVisitorID(
-            cookies.get,
-            cookies.set,
-            testWebsiteID,
-            generateConstantID("goober"),
-        );
-
-        expect(returnedID).toBe(null);
-    });
-
     test("generates UUIDs by default", () => {
-        const cookiesA = makeCookieJar();
-        const cookiesB = makeCookieJar();
+        const testWebsiteID = "websiteID";
+
+        const siteDataA = new WebsiteData(testWebsiteID, makeCookieJar());
+        const siteDataB = new WebsiteData(testWebsiteID, makeCookieJar());
 
         const sentinel = "this is not a UUID!";
 
-        const returnedIDA = ensureVisitorID(cookiesA.get, cookiesA.set, "websiteID") || sentinel;
-        const returnedIDB = ensureVisitorID(cookiesB.get, cookiesB.set, "websiteID") || sentinel;
+        const returnedIDA = ensureVisitorID(siteDataA) || sentinel;
+        const returnedIDB = ensureVisitorID(siteDataB) || sentinel;
 
         expect(looksLikeUUID(returnedIDA)).toBe(true);
         expect(looksLikeUUID(returnedIDB)).toBe(true);


### PR DESCRIPTION
Problem
======

Tickets: CON-1452, CON-1462

When configuration changes, we want any previous allocations to hold. Allocation is currently just a function of the current config.

When setting up variations, we want to allow for "empty" space to compete with the various allocations. The allocation space is currently always the combination of all variation weights.

Solution
======

Use our JSON cookie to persist allocation data (compatible with the js-sdk).

Instead of allocating inside the sum of variation weights, always allocate in 1-100 (our config backend ensures the sum is not greater than 100).

Testing
=====

New unit tests added for the cookie refactor.

Expanded the data driven SDK compatibility test suite (data driven to enable use in test suites for all platform SDKs).