### PR TITLE
Compatibility test fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- improved compatibility test suite
 - improved documentation
 
 ## [0.2.0] - 2022-05-18

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -25,10 +25,15 @@ describe("SymplifySDK client", () => {
 
             const sgCookies = JSON.parse(decodeURIComponent(cookies.get("sg_cookies") || "{}"));
 
-            for (const [keypath, regex] of Object.entries(t.expect_sg_cookie_properties_match)) {
-                const reCookie = new RegExp(regex as string);
+            for (const [keypath, expected] of Object.entries(t.expect_sg_cookie_properties_match)) {
                 const leaf = keypath.split("/").reduce((acc, p) => (acc || {})[p], sgCookies);
-                expect("" + (leaf || "null")).toMatch(reCookie);
+                if (typeof expected == "string") {
+                    const reCookie = new RegExp(expected);
+                    expect(leaf || "null").toMatch(reCookie);
+                } else {
+                    // ?? is for undefined
+                    expect(leaf ?? null).toStrictEqual(expected);
+                }
             }
 
             const reVariation = new RegExp(t.expect_variation_match);

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -126,7 +126,7 @@
     "sdk_config": "sdk_config.json",
     "website_id": "10001",
     "cookies": {
-      "sg_cookies": "{%2210001%22:{%221001_ch%22:-1%2C%22visid%22:%22goober%22}%2C%22_g%22:1}"
+      "sg_cookies": "{%2210001%22:{%221001_ch%22:-1%2C%22visid%22:%22foobar%22}%2C%22_g%22:1}"
     },
     "test_project_name": "test project",
     "expect_variation_match": null,

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -95,9 +95,9 @@
     "test_project_name": "test project",
     "expect_variation_match": "active variation 2",
     "expect_sg_cookie_properties_match": {
-      "10001/1001_ch": "1",
-      "10001/1001": "[10013]",
-      "10001/aud_p": "[1001]"
+      "10001/1001_ch": 1,
+      "10001/1001": [10013],
+      "10001/aud_p": [1001]
     }
   },
   {
@@ -118,7 +118,7 @@
     "test_project_name": "no allocations",
     "expect_variation_match": null,
     "expect_sg_cookie_properties_match": {
-      "10001/1003_ch": "-1"
+      "10001/1003_ch": -1
     }
   },
   {
@@ -164,9 +164,9 @@
     "test_project_name": "test project",
     "expect_variation_match": "active variation 2",
     "expect_sg_cookie_properties_match": {
-      "10001/1001_ch": "1",
-      "10001/1001": "[10013]",
-      "10001/aud_p": "[1001]"
+      "10001/1001_ch": 1,
+      "10001/1001": [10013],
+      "10001/aud_p": [1001]
     }
   }
 ]


### PR DESCRIPTION
Improve the data in `test/test_cases.json`.

The regexen is a holdover from the first variant of the tests that only looked at JSON strings.

"foobar" vs "goober" is just a fix of a bad choice of test data not testing the right fix (maybe it did at first but the data changed, or maybe it was never right).