### PR TITLE
fix windowed hash function, compatibility tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- windowed hash function was not rounding correctly, add `ceil` call for compatibility
 ### Changed
 - improved compatibility test suite
 - improved documentation

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -14,6 +14,17 @@ export function djb2(str: string) {
         hash = ((hash << 5) + hash) ^ c;
     }
 
-    // JS trickery to convert to unsigned 32 bits
+    // JS trickery to convert to unsigned 32 bits (truncates)
     return hash >>> 0;
+}
+
+/**
+ * Return the hash of `str` but scaled to fit in [0, `window`].
+ */
+export function hashInWindow(str: string, window: number): number {
+    let hash = djb2(str);
+    hash /= 4_294_967_295; // unsigned max
+    hash *= window; // fit window
+
+    return Math.ceil(hash);
 }

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,4 +1,4 @@
-import { djb2 } from "./hash";
+import { hashInWindow } from "./hash";
 
 export type ProjectState = "paused" | "active";
 
@@ -50,12 +50,8 @@ export function findVariationForVisitor(
         return null;
     }
 
-    const totalWeight = 100;
-
     const hashKey = `${visitorID}:${project.id}`;
-    let hash = djb2(hashKey);
-    hash /= 4_294_967_295; // unsigned max
-    hash *= totalWeight; // fit window
+    const hash = hashInWindow(hashKey, 100);
 
     let pointer = 0;
     for (const variation of project.variations) {

--- a/test/hash.test.ts
+++ b/test/hash.test.ts
@@ -1,4 +1,4 @@
-import { djb2 } from "../src/hash";
+import { djb2, hashInWindow } from "../src/hash";
 
 describe("hash is compatible", () => {
     test("djb2 empty string works", () => {
@@ -19,5 +19,21 @@ describe("hash is compatible", () => {
 
     test("djb2 UUID string 3 works", () => {
         expect(djb2("cc615f71-1ab8-4322-b7d7-e10294a8d483")).toBe(3367636261);
+    });
+
+    test("hashInWindow is distributed 1", () => {
+        expect(hashInWindow("9e66a7fa-984a-4681-9319-80c2be2ffe8a", 3)).toBe(1);
+    });
+
+    test("hashInWindow is distributed 2", () => {
+        expect(hashInWindow("72784e9c-f5ae-4aed-8ae7-baa9c6e31d3c", 3)).toBe(2);
+    });
+
+    test("hashInWindow is distributed 3", () => {
+        expect(hashInWindow("cc615f71-1ab8-4322-b7d7-e10294a8d483", 3)).toBe(3);
+    });
+
+    test("hashInWindow is compatible", () => {
+        expect(hashInWindow("b7850777-f581-4f66-ad3e-4e54963661df", 100)).toBe(57);
     });
 });


### PR DESCRIPTION
Problem
======
The Node.js version was missing a ceil operation on the scaled hash value. This means some combinations of visitor IDs and total weight in JS does not get the same result as in PHP and .NET.

Solution
======
Add call to `Math.ceiling`. Add missing tests for the windowed hash function (and refactor code to extract the function).