### PR TITLE
Add Custom Audience Support

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,23 @@
+name: Micro benchmarks
+
+on:
+  push:
+    branches: [ main, "feature/**" ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run bench

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,7 +2,7 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "feature/**" ]
   pull_request:
     branches: [ main ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 /lib
 cookies.curl.txt
+benchmark/results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- custom audience support (see docs)
 
 ## [0.3.0] - 2022-08-09
 ### Fixed

--- a/benchmark/audience.bench.js
+++ b/benchmark/audience.bench.js
@@ -1,0 +1,229 @@
+const benny = require("benny");
+
+const { Audience } = require("../lib/audience");
+
+const allAttributesMatch = () => ({
+    attributes: {
+        bonusPoints: 1000,
+        urlPath: "/contact",
+        country: "Sweden",
+    },
+});
+
+function isTruthy(aud, env) {
+    return aud.eval(env) == true;
+}
+
+const simpleAudience = new Audience(
+    JSON.stringify([
+        "all",
+        [">=", ["number-attribute", "bonusPoints"], 1000],
+        ["contains", ["string-attribute", "urlPath"], "contact"],
+        ["equals", ["string-attribute", "country"], "Sweden"],
+    ]),
+);
+
+const complexAudienceAny = new Audience(
+    JSON.stringify([
+        "any",
+        [
+            "all",
+            [">=", ["number-attribute", "bonusPoints"], 123],
+            ["equals", ["string-attribute", "country"], "Sweden"],
+        ],
+        [
+            "all",
+            [">=", ["number-attribute", "bonusPoints"], 452],
+            ["equals", ["string-attribute", "country"], "Norway"],
+        ],
+        [
+            "all",
+            [">=", ["number-attribute", "bonusPoints"], 1000],
+            ["contains", ["string-attribute", "urlPath"], "contact"],
+            ["equals", ["string-attribute", "country"], "Sweden"],
+        ],
+    ]),
+);
+
+const complexAudienceAll = new Audience(
+    JSON.stringify([
+        "all",
+        [
+            "all",
+            [">=", ["number-attribute", "bonusPoints"], 1000],
+            ["contains", ["string-attribute", "urlPath"], "contact"],
+            ["equals", ["string-attribute", "country"], "Sweden"],
+        ],
+        [
+            "all",
+            ["equals", ["string-attribute", "country"], "Sweden"],
+            [">=", ["number-attribute", "bonusPoints"], 1000],
+            ["contains", ["string-attribute", "urlPath"], "contact"],
+        ],
+        [
+            "all",
+            ["contains", ["string-attribute", "urlPath"], "contact"],
+            [">=", ["number-attribute", "bonusPoints"], 1000],
+            ["equals", ["string-attribute", "country"], "Sweden"],
+        ],
+        [
+            "any",
+            ["contains", ["string-attribute", "urlPath"], "contact"],
+            [">=", ["number-attribute", "bonusPoints"], 100],
+            ["equals", ["string-attribute", "country"], "Japan"],
+        ],
+    ]),
+);
+
+const superComplexAudience = new Audience(
+    JSON.stringify([
+        "all",
+        [
+            "all",
+            [">=", ["number-attribute", "bonusPoints"], 1000],
+            ["contains", ["string-attribute", "urlPath"], "contact"],
+            ["equals", ["string-attribute", "country"], "Sweden"],
+        ],
+        [
+            "any",
+            [
+                "all",
+                [">=", ["number-attribute", "bonusPoints"], 123],
+                ["equals", ["string-attribute", "country"], "Sweden"],
+            ],
+            [
+                "all",
+                [">=", ["number-attribute", "bonusPoints"], 452],
+                ["equals", ["string-attribute", "country"], "Norway"],
+            ],
+            [
+                "all",
+                [">=", ["number-attribute", "bonusPoints"], 1000],
+                [
+                    "all",
+                    ["equals", ["string-attribute", "country"], "Sweden"],
+                    [">=", ["number-attribute", "bonusPoints"], 1000],
+                    ["contains", ["string-attribute", "urlPath"], "contact"],
+                ],
+                ["contains", ["string-attribute", "urlPath"], "contact"],
+                ["equals", ["string-attribute", "country"], "Sweden"],
+            ],
+        ],
+        [
+            "all",
+            ["equals", ["string-attribute", "country"], "Sweden"],
+            [">=", ["number-attribute", "bonusPoints"], 1000],
+            ["contains", ["string-attribute", "urlPath"], "contact"],
+        ],
+        [
+            "all",
+            ["contains", ["string-attribute", "urlPath"], "contact"],
+            [
+                "any",
+                [
+                    "all",
+                    [">=", ["number-attribute", "bonusPoints"], 123],
+                    ["equals", ["string-attribute", "country"], "Sweden"],
+                ],
+                [
+                    "all",
+                    [">=", ["number-attribute", "bonusPoints"], 452],
+                    ["equals", ["string-attribute", "country"], "Norway"],
+                ],
+            ],
+            ["equals", ["string-attribute", "country"], "Sweden"],
+        ],
+        [
+            "any",
+            ["contains", ["string-attribute", "urlPath"], "contact"],
+            [">=", ["number-attribute", "bonusPoints"], 100],
+            ["equals", ["string-attribute", "country"], "Japan"],
+        ],
+    ]),
+);
+
+const attrs = allAttributesMatch();
+
+//
+// This is slightly abusing benny, but informative nonetheless
+//
+
+function bench(name, variants) {
+    const fns = [];
+    for (const [name, code] of Object.entries(variants)) {
+        fns.push(benny.add(name, code));
+    }
+    fns.push(
+        benny.cycle(),
+        benny.complete(),
+        benny.save({ file: name, version: "1.0.0" }),
+        benny.save({ file: name, format: "chart.html" }),
+    );
+    benny.suite(name, ...fns);
+}
+
+bench("typical-audience-true", {
+    "no env alloc": () => {
+        return isTruthy(simpleAudience, attrs);
+    },
+    "env alloc": () => {
+        return isTruthy(simpleAudience, allAttributesMatch());
+    },
+});
+
+bench("complex-audience-true", {
+    "complex all, env alloc": () => {
+        return isTruthy(complexAudienceAll, allAttributesMatch());
+    },
+    "complex any, env alloc": () => {
+        return isTruthy(complexAudienceAny, allAttributesMatch());
+    },
+    "super complex, env alloc": () => {
+        return isTruthy(superComplexAudience, allAttributesMatch());
+    },
+});
+
+const noAttributes = () => ({
+    attributes: {},
+});
+
+const allAttributesNoMatchFirst = () => ({
+    attributes: {
+        bonusPoints: 999,
+        urlPath: "/contact",
+        country: "Sweden",
+    },
+});
+
+const allAttributesNoMatchLast = () => ({
+    attributes: {
+        bonusPoints: 1000,
+        urlPath: "/contact",
+        country: "Norway",
+    },
+});
+
+const empty = noAttributes();
+const badFirst = allAttributesNoMatchFirst();
+const badLast = allAttributesNoMatchLast();
+
+bench("typical-audience-false", {
+    "immediate error, no env alloc": () => {
+        return isTruthy(simpleAudience, empty);
+    },
+    "immediate error, env alloc": () => {
+        return isTruthy(simpleAudience, noAttributes());
+    },
+    "first false, no env alloc": () => {
+        return isTruthy(simpleAudience, badFirst);
+    },
+    "last false, no env alloc": () => {
+        return isTruthy(simpleAudience, badLast);
+    },
+    "first false, env alloc": () => {
+        return isTruthy(simpleAudience, allAttributesNoMatchFirst());
+    },
+    "last false, env alloc": () => {
+        return isTruthy(simpleAudience, allAttributesNoMatchLast());
+    },
+});

--- a/docs/Audiences.md
+++ b/docs/Audiences.md
@@ -1,0 +1,168 @@
+# Audiences
+
+## Purpose
+
+The purpose of this docuemnt is to specify how all SDK implementations should
+interpret audience rules.
+
+## Overview
+
+A project can have custom audience rules applied for segmentation.
+
+The project audience is defined by an expression of rules which when applied to
+the request context can be true or false.
+
+A project with no custom audience defined behaves the same as one which has an
+audience that is always true.
+
+When finding a variation, the first thing the SDK does (after finding the
+project) is to apply the audience rules. If the request is not within the
+audience, no allocation is attempted and the result is not persisted. If the
+audience is fulfilled, variation allocation proceeds as if no audience was
+configured.
+
+The expressions in the data come from the server side testing config in our
+backend, and is built by users creating the test projects. As such there should
+be no errors in the given expressions but this document nonetheless describes
+how to handle them.
+
+The audience evaluation never throws exceptions, when we say an error is raised
+below, we mean the evaluation is aborted and the result is false.
+
+## Syntax
+
+Rules are defined in JSON s-expressions.
+
+There are some general operations for comparing numbers and strings, and for
+combining booleans.
+
+There are also functions for getting custom request or visitor attributes. Note
+that these attributes are all provided by the SDK user in the call to find a
+project variation.
+
+Here are some examples to illustrate.
+
+This audience is true if the string attribute `urlPath` contains the string
+"contact" and also the string attribute `country` is "Sweden":
+
+```JSON
+["all",
+  ["contains", ["string-attribute", "urlPath"], "contact"],
+  ["equals", ["string-attribute", "country"], "Sweden"]]
+```
+
+This audience is true if the bool attribute `preview` is true, or else if the
+string attribute `environment` is "staging":
+
+```JSON
+["any",
+  ["bool-attribute", "preview"],
+  ["equals", ["string-attribute", "environment"], "staging"]]
+```
+
+The JSON s-expressions are either atoms or lists of s-expressions.
+
+An atom is a JSON string, boolean or number.
+
+A list is a JSON array.
+
+## Evaluating
+
+The value of an atom is its value in JSON.
+
+(pseudo meta syntax)
+```
+"foo" => "foo"
+true  => true
+4711  => 4711
+```
+
+The value of a list is the result of applying the primitive named by the first
+element on the arguments in the rest of the list.
+
+(pseudo meta syntax)
+```
+["foo", "bar", "baz"] => lookupPrimitive("foo").apply("bar", "baz")
+["quux"]              => lookupPrimitive("quux").apply()
+```
+
+If a primitive lookup fails, an error is raised.
+
+## Primitives
+
+The audience expressions are built by combining the following primitives.
+
+The arity of each operation is listed by its name.
+
+Passing the wrong number or type of arguments yields an error. An audience with
+an error behaves like one which has a false result.
+
+### Facts
+
+Facts contain information related to a request, they can return numbers, strings
+or booleans.
+
+#### string-attribute (unary)
+
+returns the string attribute named by the first argument, from the request
+environment
+
+if none is found, the whole audience is false
+
+#### number-attribute (unary)
+
+returns the number attribute named by the first argument, from the request
+environment
+
+if none is found, the whole audience is false
+
+#### bool-attribute (unary)
+
+returns the boolean attribute named by the first argument, from the request
+environment
+
+if none is found, the whole audience is false
+
+### Boolean operations
+
+#### all (variadic)
+returns true if all arguments are true (true for an empty argument list)
+
+#### any (variadic)
+returns true if any arguments is true (false for empty arg list)
+
+#### not (unary)
+returns the inverse of its boolean argument
+
+### Binary number comparisons
+
+These primitives take exactly two number arguments, otherwise raise an error.
+
+#### == (binary)
+returns true if the arguments are equal
+
+#### < (binary)
+returns true if the first argument is less than the second
+
+#### <= (binary)
+returns true if the first argument is less than or equal to the second
+
+#### > (binary)
+returns true if the first argument is greater than the second
+
+#### >= (binary)
+returns true if the first argument is greater than or equal to the second
+
+### Binary string comparisons
+
+These primitives take exactly two string arguments, otherwise raise an error.
+They are all case insensitive.
+
+#### equals (binary)
+returns true if arguments are equal
+
+#### contains (binary)
+returns true if the first argument contains the second
+
+#### matches (binary)
+returns true it the first argument matches the second (second interpreted as regex)

--- a/docs/Audiences.md
+++ b/docs/Audiences.md
@@ -43,10 +43,12 @@ project variation.
 Here are some examples to illustrate.
 
 This audience is true if the string attribute `urlPath` contains the string
-"contact" and also the string attribute `country` is "Sweden":
+"contact" and also the string attribute `country` is "Sweden" and the
+`bonusPoints` number attribute is at least 1000:
 
 ```JSON
 ["all",
+  [">=", ["number-attribute", "bonusPoints"], 1000],
   ["contains", ["string-attribute", "urlPath"], "contact"],
   ["equals", ["string-attribute", "country"], "Sweden"]]
 ```

--- a/examples/custom-audience/README.md
+++ b/examples/custom-audience/README.md
@@ -1,0 +1,35 @@
+# custom-audience
+
+This is an example server built with https://expressjs.com.
+
+It is a somewhat minimal example using the server side testing SDK with a custom
+audience.
+
+## Dependencies
+
+See [the examples README](../README.md). The code below assumes the suggested
+host and ports are used, modify as needed.
+
+## Running
+
+```shell
+npm install
+export SSTSDK_CDNHOST=fake-cdn.localhost.test
+export SSTSDK_CDNPORT=3443
+npm run start
+```
+
+```shell
+watch curl --silent 'http://localhost:3000/hello?lang=en'
+```
+
+The curl output will start to vary as soon as the sst configuration has been loaded.
+
+Passing any `lang` parameter other than "en" makes the custom audience not
+match, meaning you should not see any variation.
+
+You can test it with cookies as well, to see the consistent variation allocation:
+
+```shell
+watch curl --silent --cookie cookies.curl.txt --cookie-jar cookies.curl.txt 'http://localhost:3000/hello?lang=en'
+```

--- a/examples/custom-audience/index.js
+++ b/examples/custom-audience/index.js
@@ -1,0 +1,65 @@
+const express = require('express');
+const cookieParser = require('cookie-parser')
+const sstsdk = require('@symplify-conversion/sst-sdk-nodejs');
+
+const websiteID = process.env['SSTSDK_WEBSITEID'] || "1337";
+const cdnHost = process.env['SSTSDK_CDNHOST'] || "fake-cdn.localhost.test";
+const cdnPort = process.env['SSTSDK_CDNPORT'] || "3443"
+
+const app = express();
+const port = 3000;
+app.use(cookieParser())
+
+// When instatiating the SDK we can override the default dependencies,
+// for this example we want to use a local fake CDN (see README.md),
+// and we want the SDK to log to the console instead of being silent.
+const overrides = {
+    cdnBaseURL: `https://${cdnHost}:${cdnPort}`,
+    log: console,
+};
+
+const sst = new sstsdk(websiteID, overrides);
+
+// An express adapter for the CookieJar interface
+function cookieJar(req, res) {
+    return {
+        get: (name) => req.cookies[name],
+        set: (name, value) => res.cookie(name, value),
+    }
+}
+
+function getGreeting(req, res) {
+
+    let greeting = '';
+    const language = req.query.lang || 'en';
+
+    switch (language) {
+        case 'sv':
+            greeting = 'Hej världen';
+            break;
+        case 'en':
+        default:
+            greeting = 'Hello, World';
+            break;
+    }
+
+    // N.B. that the `language` attribute must be present and a string, if the project audience uses it
+    switch (sst.findVariation('greeting-enthusiasm', cookieJar(req, res), { language })) {
+        case 'high':
+            greeting += "!";
+            break;
+        default:
+            greeting += ".";
+            break;
+    }
+
+    return greeting;
+}
+
+app.get('/hello', (req, res) => {
+    res.send(`<h2> ${getGreeting(req, res)} </h2>`);
+})
+
+app.listen(port, () => {
+    console.log(`Example app listening on http://localhost:${port} (websiteID: ${websiteID})`);
+})

--- a/examples/custom-audience/package-lock.json
+++ b/examples/custom-audience/package-lock.json
@@ -1,0 +1,1060 @@
+{
+  "name": "custom-audience",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@symplify-conversion/sst-sdk-nodejs": "file:../../lib",
+        "cookie-parser": "^1.4.6",
+        "express": "^4.18.1"
+      }
+    },
+    "../../lib": {},
+    "node_modules/@symplify-conversion/sst-sdk-nodejs": {
+      "resolved": "../../lib",
+      "link": true
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.10.3",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.0",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.10.3",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "dependencies": {
+    "@symplify-conversion/sst-sdk-nodejs": {
+      "version": "file:../../lib"
+    },
+    "accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "requires": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "body-parser": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "requires": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.10.3",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      }
+    },
+    "bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "requires": {
+        "safe-buffer": "5.2.1"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      }
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
+    "destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
+    "express": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "requires": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.0",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.10.3",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+        }
+      }
+    },
+    "finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
+    "http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "requires": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "object-inspect": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+    },
+    "on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "qs": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "requires": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
+    "statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+    },
+    "toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    }
+  }
+}

--- a/examples/custom-audience/package.json
+++ b/examples/custom-audience/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@symplify-conversion/sst-sdk-nodejs": "file:../../lib",
+    "cookie-parser": "^1.4.6",
+    "express": "^4.18.1"
+  }
+}
+

--- a/examples/fakeCDN/1337/sstConfig.json
+++ b/examples/fakeCDN/1337/sstConfig.json
@@ -1,0 +1,16 @@
+{
+  "updated": 1651493828,
+  "privacy_mode": 0,
+  "projects": [
+    {
+      "id": 3002,
+      "name": "greeting-enthusiasm",
+      "audience_rules": ["equals", "en", ["string-attribute", "language"]],
+      "variations": [
+        { "id": 30021, "name": "Original", "weight": 50, "state": "active" },
+        { "id": 30022, "name": "high", "weight": 50, "state": "active" }
+      ],
+      "state": "active"
+    }
+  ]
+}

--- a/examples/hello-express/README.md
+++ b/examples/hello-express/README.md
@@ -12,6 +12,7 @@ host and ports are used, modify as needed.
 ## Running
 
 ```shell
+npm install
 export SSTSDK_CDNHOST=fake-cdn.localhost.test
 export SSTSDK_CDNPORT=3443
 npm run start

--- a/examples/page-variations/README.md
+++ b/examples/page-variations/README.md
@@ -16,6 +16,7 @@ host and ports are used, modify as needed.
 ## Running
 
 ```shell
+npm install
 export SSTSDK_CDNHOST=fake-cdn.localhost.test
 export SSTSDK_CDNPORT=3443
 npm run start

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@symplify-conversion/sst-sdk-nodejs",
-  "version": "0.3.1-dev",
+  "version": "0.4.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@symplify-conversion/sst-sdk-nodejs",
-      "version": "0.3.1-dev",
+      "version": "0.4.0-dev",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.4.1",
         "@typescript-eslint/eslint-plugin": "^5.21.0",
         "@typescript-eslint/parser": "^5.21.0",
+        "benny": "^3.7.1",
         "eslint": "^8.14.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
@@ -36,6 +37,48 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@arrows/array": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@arrows/array/-/array-1.4.1.tgz",
+      "integrity": "sha512-MGYS8xi3c4tTy1ivhrVntFvufoNzje0PchjEz6G/SsWRgUKxL4tKwS6iPdO8vsaJYldagAeWMd5KRD0aX3Q39g==",
+      "dev": true,
+      "dependencies": {
+        "@arrows/composition": "^1.2.2"
+      }
+    },
+    "node_modules/@arrows/composition": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@arrows/composition/-/composition-1.2.2.tgz",
+      "integrity": "sha512-9fh1yHwrx32lundiB3SlZ/VwuStPB4QakPsSLrGJFH6rCXvdrd060ivAZ7/2vlqPnEjBkPRRXOcG1YOu19p2GQ==",
+      "dev": true
+    },
+    "node_modules/@arrows/dispatch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@arrows/dispatch/-/dispatch-1.0.3.tgz",
+      "integrity": "sha512-v/HwvrFonitYZM2PmBlAlCqVqxrkIIoiEuy5bQgn0BdfvlL0ooSBzcPzTMrtzY8eYktPyYcHg8fLbSgyybXEqw==",
+      "dev": true,
+      "dependencies": {
+        "@arrows/composition": "^1.2.2"
+      }
+    },
+    "node_modules/@arrows/error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@arrows/error/-/error-1.0.2.tgz",
+      "integrity": "sha512-yvkiv1ay4Z3+Z6oQsUkedsQm5aFdyPpkBUQs8vejazU/RmANABx6bMMcBPPHI4aW43VPQmXFfBzr/4FExwWTEA==",
+      "dev": true
+    },
+    "node_modules/@arrows/multimethod": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@arrows/multimethod/-/multimethod-1.4.1.tgz",
+      "integrity": "sha512-AZnAay0dgPnCJxn3We5uKiB88VL+1ZIF2SjZohLj6vqY2UyvB/sKdDnFP+LZNVsTC5lcnGPmLlRRkAh4sXkXsQ==",
+      "dev": true,
+      "dependencies": {
+        "@arrows/array": "^1.4.1",
+        "@arrows/composition": "^1.2.2",
+        "@arrows/error": "^1.0.2",
+        "fast-deep-equal": "^3.1.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1761,6 +1804,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "28.0.3",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.0.3.tgz",
@@ -1857,6 +1909,45 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
+    "node_modules/benny": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/benny/-/benny-3.7.1.tgz",
+      "integrity": "sha512-USzYxODdVfOS7JuQq/L0naxB788dWCiUgUTxvN+WLPt/JfcDURNNj8kN/N+uK6PDvuR67/9/55cVKGPleFQINA==",
+      "dev": true,
+      "dependencies": {
+        "@arrows/composition": "^1.0.0",
+        "@arrows/dispatch": "^1.0.2",
+        "@arrows/multimethod": "^1.1.6",
+        "benchmark": "^2.1.4",
+        "common-tags": "^1.8.0",
+        "fs-extra": "^10.0.0",
+        "json2csv": "^5.0.6",
+        "kleur": "^4.1.4",
+        "log-update": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/benny/node_modules/kleur": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2020,6 +2111,18 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2064,6 +2167,24 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2887,6 +3008,20 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -4151,6 +4286,24 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "node_modules/json2csv": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.7.tgz",
+      "integrity": "sha512-YRZbUnyaJZLZUJSRi2G/MqahCyRv9n/ds+4oIetjDF3jWQA7AG7iSeKTiZiCNqtMZM7HDyt0e/W6lEnoGEmMGA==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^6.1.0",
+        "jsonparse": "^1.3.1",
+        "lodash.get": "^4.4.2"
+      },
+      "bin": {
+        "json2csv": "bin/json2csv.js"
+      },
+      "engines": {
+        "node": ">= 10",
+        "npm": ">= 6.13.0"
+      }
+    },
     "node_modules/json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -4162,6 +4315,27 @@
       "bin": {
         "json5": "lib/cli.js"
       }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ]
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -4213,6 +4387,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -4224,6 +4410,38 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -4698,6 +4916,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4886,6 +5110,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -5009,6 +5246,23 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/source-map": {
@@ -5459,6 +5713,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5640,6 +5903,48 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@arrows/array": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@arrows/array/-/array-1.4.1.tgz",
+      "integrity": "sha512-MGYS8xi3c4tTy1ivhrVntFvufoNzje0PchjEz6G/SsWRgUKxL4tKwS6iPdO8vsaJYldagAeWMd5KRD0aX3Q39g==",
+      "dev": true,
+      "requires": {
+        "@arrows/composition": "^1.2.2"
+      }
+    },
+    "@arrows/composition": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@arrows/composition/-/composition-1.2.2.tgz",
+      "integrity": "sha512-9fh1yHwrx32lundiB3SlZ/VwuStPB4QakPsSLrGJFH6rCXvdrd060ivAZ7/2vlqPnEjBkPRRXOcG1YOu19p2GQ==",
+      "dev": true
+    },
+    "@arrows/dispatch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@arrows/dispatch/-/dispatch-1.0.3.tgz",
+      "integrity": "sha512-v/HwvrFonitYZM2PmBlAlCqVqxrkIIoiEuy5bQgn0BdfvlL0ooSBzcPzTMrtzY8eYktPyYcHg8fLbSgyybXEqw==",
+      "dev": true,
+      "requires": {
+        "@arrows/composition": "^1.2.2"
+      }
+    },
+    "@arrows/error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@arrows/error/-/error-1.0.2.tgz",
+      "integrity": "sha512-yvkiv1ay4Z3+Z6oQsUkedsQm5aFdyPpkBUQs8vejazU/RmANABx6bMMcBPPHI4aW43VPQmXFfBzr/4FExwWTEA==",
+      "dev": true
+    },
+    "@arrows/multimethod": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@arrows/multimethod/-/multimethod-1.4.1.tgz",
+      "integrity": "sha512-AZnAay0dgPnCJxn3We5uKiB88VL+1ZIF2SjZohLj6vqY2UyvB/sKdDnFP+LZNVsTC5lcnGPmLlRRkAh4sXkXsQ==",
+      "dev": true,
+      "requires": {
+        "@arrows/array": "^1.4.1",
+        "@arrows/composition": "^1.2.2",
+        "@arrows/error": "^1.0.2",
+        "fast-deep-equal": "^3.1.3"
       }
     },
     "@babel/code-frame": {
@@ -6946,6 +7251,12 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
+    },
     "babel-jest": {
       "version": "28.0.3",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.0.3.tgz",
@@ -7021,6 +7332,41 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
+    "benny": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/benny/-/benny-3.7.1.tgz",
+      "integrity": "sha512-USzYxODdVfOS7JuQq/L0naxB788dWCiUgUTxvN+WLPt/JfcDURNNj8kN/N+uK6PDvuR67/9/55cVKGPleFQINA==",
+      "dev": true,
+      "requires": {
+        "@arrows/composition": "^1.0.0",
+        "@arrows/dispatch": "^1.0.2",
+        "@arrows/multimethod": "^1.1.6",
+        "benchmark": "^2.1.4",
+        "common-tags": "^1.8.0",
+        "fs-extra": "^10.0.0",
+        "json2csv": "^5.0.6",
+        "kleur": "^4.1.4",
+        "log-update": "^4.0.0"
+      },
+      "dependencies": {
+        "kleur": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+          "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+          "dev": true
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -7134,6 +7480,15 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -7170,6 +7525,18 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true
+    },
+    "common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
       "dev": true
     },
     "concat-map": {
@@ -7805,6 +8172,17 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
+    },
+    "fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -8730,6 +9108,17 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json2csv": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.7.tgz",
+      "integrity": "sha512-YRZbUnyaJZLZUJSRi2G/MqahCyRv9n/ds+4oIetjDF3jWQA7AG7iSeKTiZiCNqtMZM7HDyt0e/W6lEnoGEmMGA==",
+      "dev": true,
+      "requires": {
+        "commander": "^6.1.0",
+        "jsonparse": "^1.3.1",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -8738,6 +9127,22 @@
       "requires": {
         "minimist": "^1.2.0"
       }
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true
     },
     "kleur": {
       "version": "3.0.3",
@@ -8777,6 +9182,18 @@
         "path-exists": "^3.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8788,6 +9205,31 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -9143,6 +9585,12 @@
         }
       }
     },
+    "platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9264,6 +9712,16 @@
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -9346,6 +9804,17 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -9649,6 +10118,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
     "dev": "tsc --watch",
     "lint": "eslint src test",
     "build": "tsc",
+    "bench": "npm run build && find benchmark -name '*bench*.js' | xargs node",
     "test": "jest"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
+    "benny": "^3.7.1",
     "eslint": "^8.14.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@symplify-conversion/sst-sdk-nodejs",
-  "version": "0.3.1-dev",
+  "version": "0.4.0-dev",
   "description": "This is the Node.js implementation of the Symplify Server-Side Testing SDK.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/audience.ts
+++ b/src/audience.ts
@@ -81,6 +81,8 @@ export class Audience {
     }
 
     private evalApply(head: string, args: List, env: Environment): Atom | AudienceError {
+        // TODO(Fabian) we have some extensibility in mind for primitives,
+        // might want to rephrase this or refactor where the lookup is.
         const prim = primitives[head];
         if (!prim) {
             return { message: `${head} is not a primitive` };
@@ -126,6 +128,8 @@ function checkSyntaxInner(ast: AST): void {
                 if (typeof car != "string") {
                     throw { message: `can only apply strings, ${car} is not a string` };
                 }
+                // TODO(Fabian) not sure yet if we want to test this statically,
+                // we have some extensibility in mind with regards to callable functions.
                 if (!primitives[car]) {
                     throw { message: `${car} is not a primitive` };
                 }

--- a/src/audience.ts
+++ b/src/audience.ts
@@ -94,7 +94,7 @@ export class Audience {
                 }
                 evaledArgs.push(a);
             }
-            return prim.apply(prim, evaledArgs);
+            return prim(evaledArgs, env);
         } catch {
             return { message: `error applying primitive ${head}` };
         }
@@ -156,13 +156,14 @@ function numberFun(a: Atom, b: Atom, op: (x: number, y: number) => Atom): Audien
 // eslint-disable-next-line @typescript-eslint/ban-types
 const primitives: Record<string, Function> = {
     // boolean operations
-    not: (arg: Atom) => {
+    not: (args: Atom[]) => {
+        const [arg] = args;
         if (typeof arg == "boolean") {
             return !arg;
         }
         return { message: `${arg} is not a boolean` };
     },
-    all: (...args: List) => {
+    all: (args: Atom[]) => {
         for (const arg of args) {
             if (!(typeof arg == "boolean")) {
                 return { message: `${arg} is not a boolean` };
@@ -173,7 +174,7 @@ const primitives: Record<string, Function> = {
         }
         return true;
     },
-    any: (...args: List) => {
+    any: (args: Atom[]) => {
         for (const arg of args) {
             if (!(typeof arg == "boolean")) {
                 return { message: `${arg} is not a boolean` };
@@ -186,18 +187,56 @@ const primitives: Record<string, Function> = {
     },
 
     // string comparisons
-    equals: (a: Atom, b: Atom) => stringFun(a, b, (a, b) => a == b),
-    contains: (a: Atom, b: Atom) => stringFun(a, b, (a, b) => a.includes(b)),
-    matches: (a: Atom, b: Atom) => stringFun(a, b, (a, b) => new RegExp(b).test(a)),
+    equals: (args: Atom[]) => stringFun(args[0], args[1], (a, b) => a == b),
+    contains: (args: Atom[]) => stringFun(args[0], args[1], (a, b) => a.includes(b)),
+    matches: (args: Atom[]) => stringFun(args[0], args[1], (a, b) => new RegExp(b).test(a)),
 
     // number comparisons
-    "==": (a: Atom, b: Atom) => numberFun(a, b, (a, b) => a == b),
-    "!=": (a: Atom, b: Atom) => numberFun(a, b, (a, b) => a != b),
-    "<": (a: Atom, b: Atom) => numberFun(a, b, (a, b) => a < b),
-    "<=": (a: Atom, b: Atom) => numberFun(a, b, (a, b) => a <= b),
-    ">": (a: Atom, b: Atom) => numberFun(a, b, (a, b) => a > b),
-    ">=": (a: Atom, b: Atom) => numberFun(a, b, (a, b) => a >= b),
+    "==": (args: Atom[]) => numberFun(args[0], args[1], (a, b) => a == b),
+    "!=": (args: Atom[]) => numberFun(args[0], args[1], (a, b) => a != b),
+    "<": (args: Atom[]) => numberFun(args[0], args[1], (a, b) => a < b),
+    "<=": (args: Atom[]) => numberFun(args[0], args[1], (a, b) => a <= b),
+    ">": (args: Atom[]) => numberFun(args[0], args[1], (a, b) => a > b),
+    ">=": (args: Atom[]) => numberFun(args[0], args[1], (a, b) => a >= b),
+
+    // custom attribute getters
+    "number-attribute": (args: Atom[], env: Environment) => getInEnvNumber(args[0], env),
+    "string-attribute": (args: Atom[], env: Environment) => getInEnvString(args[0], env),
+    "bool-attribute": (args: Atom[], env: Environment) => getInEnvBool(args[0], env),
 };
+
+function getInEnvNumber(name: Atom, env: Environment): number | AudienceError {
+    if (typeof name != "string") {
+        return { message: "can only look up string names" };
+    }
+    const val = env.attributes[name];
+    if (typeof val != "number") {
+        return { message: `'${name}' is not a number` };
+    }
+    return val;
+}
+
+function getInEnvString(name: Atom, env: Environment): string | AudienceError {
+    if (typeof name != "string") {
+        return { message: "can only look up string names" };
+    }
+    const val = env.attributes[name];
+    if (typeof val != "string") {
+        return { message: `'${name}' is not a string` };
+    }
+    return val;
+}
+
+function getInEnvBool(name: Atom, env: Environment): boolean | AudienceError {
+    if (typeof name != "string") {
+        return { message: "can only look up string names" };
+    }
+    const val = env.attributes[name];
+    if (typeof val != "boolean") {
+        return { message: `'${name}' is not a boolean` };
+    }
+    return val;
+}
 
 function isError(x: Atom | AudienceError): x is AudienceError {
     return (x as AudienceError).message !== undefined;

--- a/src/audience.ts
+++ b/src/audience.ts
@@ -1,0 +1,133 @@
+export type AudienceError = {
+    message: string;
+};
+
+export type Atom = string | number | boolean;
+export type List = Array<List | Atom>;
+export type AST = Atom | List;
+
+export type Environment = {
+    attributes: Record<string, Atom>;
+};
+
+export class Audience {
+    ast: AST;
+
+    constructor(json: string) {
+        this.ast = JSON.parse(json);
+    }
+
+    eval(env: Environment): boolean | AudienceError {
+        const result = this.evalAst(this.ast, env);
+
+        if (isError(result)) {
+            return result;
+        }
+
+        if (!(typeof result == "boolean")) {
+            return { message: `audience result was not boolean (${result})` };
+        }
+
+        return result;
+    }
+
+    evalAst(ast: AST, env: Environment): Atom | AudienceError {
+        switch (typeof ast) {
+            case "number":
+                return ast;
+            case "string":
+                return ast;
+            case "boolean":
+                return ast;
+            case "object":
+                if (ast instanceof Array && typeof ast[0] == "string") {
+                    return this.evalApply(ast[0], ast.slice(1), env);
+                }
+        }
+        return { message: `cannot evaluate ${ast}` };
+    }
+
+    evalApply(head: string, args: List, env: Environment): Atom | AudienceError {
+        const prim = primitives[head];
+        if (!prim) {
+            return { message: `${head} is not a primitive` };
+        }
+        try {
+            const evaledArgs: Atom[] = [];
+            for (const arg of args) {
+                const a = this.evalAst(arg, env);
+                if (isError(a)) {
+                    return a;
+                }
+                evaledArgs.push(a);
+            }
+            return prim.apply(prim, evaledArgs);
+        } catch {
+            return { message: `error applying primitive ${head}` };
+        }
+    }
+}
+
+function stringFun(a: Atom, b: Atom, op: (x: string, y: string) => Atom): AudienceError | Atom {
+    if (typeof a != "string" || typeof b != "string") {
+        return { message: "expected string arguments" };
+    }
+    return op(a, b);
+}
+
+function numberFun(a: Atom, b: Atom, op: (x: number, y: number) => Atom): AudienceError | Atom {
+    if (typeof a != "number" || typeof b != "number") {
+        return { message: "expected number arguments" };
+    }
+    return op(a, b);
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+const primitives: Record<string, Function> = {
+    // boolean operations
+    not: (arg: Atom) => {
+        if (typeof arg == "boolean") {
+            return !arg;
+        }
+        return { message: `${arg} is not a boolean` };
+    },
+    all: (...args: List) => {
+        for (const arg of args) {
+            if (!(typeof arg == "boolean")) {
+                return { message: `${arg} is not a boolean` };
+            }
+            if (!arg) {
+                return false;
+            }
+        }
+        return true;
+    },
+    any: (...args: List) => {
+        for (const arg of args) {
+            if (!(typeof arg == "boolean")) {
+                return { message: `${arg} is not a boolean` };
+            }
+            if (arg) {
+                return true;
+            }
+        }
+        return false;
+    },
+
+    // string comparisons
+    equals: (a: Atom, b: Atom) => stringFun(a, b, (a, b) => a == b),
+    contains: (a: Atom, b: Atom) => stringFun(a, b, (a, b) => a.includes(b)),
+    matches: (a: Atom, b: Atom) => stringFun(a, b, (a, b) => new RegExp(b).test(a)),
+
+    // number comparisons
+    "==": (a: Atom, b: Atom) => numberFun(a, b, (a, b) => a == b),
+    "!=": (a: Atom, b: Atom) => numberFun(a, b, (a, b) => a != b),
+    "<": (a: Atom, b: Atom) => numberFun(a, b, (a, b) => a < b),
+    "<=": (a: Atom, b: Atom) => numberFun(a, b, (a, b) => a <= b),
+    ">": (a: Atom, b: Atom) => numberFun(a, b, (a, b) => a > b),
+    ">=": (a: Atom, b: Atom) => numberFun(a, b, (a, b) => a >= b),
+};
+
+function isError(x: Atom | AudienceError): x is AudienceError {
+    return (x as AudienceError).message !== undefined;
+}

--- a/src/audience.ts
+++ b/src/audience.ts
@@ -2,32 +2,24 @@
 // See Audience.md in docs/
 //
 
-/**
- * Evaluating an audience can yield a runtime error.
- */
-export type AudienceError = {
-    message: string;
-};
+import {
+    AST,
+    Atom,
+    Environment,
+    evalAst,
+    isError,
+    parse,
+    PrimitiveFn,
+    RulesEngineError,
+} from "./rules-engine";
 
-/**
- * The rules syntax is a subset of JSON.
- */
-export type AST = Atom | List;
-export type Atom = string | number | boolean;
-export type List = Array<List | Atom>;
-
-/**
- * The environment is passed in from the outside when evaluating rules
- */
-export type Environment = {
-    attributes: Record<string, Atom>;
-};
+type AudienceError = RulesEngineError;
 
 /**
  * Audience contains rules to be evaluated for activating projects.
  */
 export class Audience {
-    ast: AST;
+    rules: AST;
 
     /**
      * Create a new Audience with the given rules.
@@ -36,14 +28,13 @@ export class Audience {
      * @param rules JSON string describing the audience rules, see docs/Audience.md
      */
     constructor(rules: string) {
-        let ast: AST;
-        try {
-            ast = JSON.parse(rules);
-        } catch (x) {
-            throw { message: "rules syntax error" };
+        const result = parse(rules, Object.keys(primitives));
+
+        if (isError(result)) {
+            throw result;
         }
-        checkSyntax(ast);
-        this.ast = ast;
+
+        this.rules = result;
     }
 
     /**
@@ -51,7 +42,7 @@ export class Audience {
      * the audience matches.
      */
     eval(env: Environment): boolean | AudienceError {
-        const result = this.evalAst(this.ast, env);
+        const result = evalAst(this.rules, env, primitives);
 
         if (isError(result)) {
             return result;
@@ -63,84 +54,6 @@ export class Audience {
 
         return result;
     }
-
-    private evalAst(ast: AST, env: Environment): Atom | AudienceError {
-        switch (typeof ast) {
-            case "number":
-                return ast;
-            case "string":
-                return ast;
-            case "boolean":
-                return ast;
-            case "object":
-                if (ast instanceof Array && typeof ast[0] == "string") {
-                    return this.evalApply(ast[0], ast.slice(1), env);
-                }
-        }
-        return { message: `cannot evaluate ${ast}` };
-    }
-
-    private evalApply(head: string, args: List, env: Environment): Atom | AudienceError {
-        // TODO(Fabian) we have some extensibility in mind for primitives,
-        // might want to rephrase this or refactor where the lookup is.
-        const prim = primitives[head];
-        if (!prim) {
-            return { message: `${head} is not a primitive` };
-        }
-        try {
-            const evaledArgs: Atom[] = [];
-            for (const arg of args) {
-                const a = this.evalAst(arg, env);
-                if (isError(a)) {
-                    return a;
-                }
-                evaledArgs.push(a);
-            }
-            return prim(evaledArgs, env);
-        } catch {
-            return { message: `error applying primitive ${head}` };
-        }
-    }
-}
-
-function checkSyntax(ast: AST): void {
-    switch (typeof ast) {
-        case "object":
-            if (ast instanceof Array) {
-                checkSyntaxInner(ast);
-            }
-            return;
-    }
-    throw { message: "AST root must be a list" };
-}
-
-function checkSyntaxInner(ast: AST): void {
-    switch (typeof ast) {
-        case "number":
-            return;
-        case "string":
-            return;
-        case "boolean":
-            return;
-        case "object":
-            if (ast instanceof Array) {
-                const car = ast[0];
-                if (typeof car != "string") {
-                    throw { message: `can only apply strings, ${car} is not a string` };
-                }
-                // TODO(Fabian) not sure yet if we want to test this statically,
-                // we have some extensibility in mind with regards to callable functions.
-                if (!primitives[car]) {
-                    throw { message: `${car} is not a primitive` };
-                }
-                const cdr = ast.slice(1);
-                for (const elem of cdr) {
-                    checkSyntaxInner(elem);
-                }
-                return;
-            }
-    }
-    throw { message: `rules syntax error at ${JSON.stringify(ast)}` };
 }
 
 function stringFun(a: Atom, b: Atom, op: (x: string, y: string) => Atom): AudienceError | Atom {
@@ -157,8 +70,7 @@ function numberFun(a: Atom, b: Atom, op: (x: number, y: number) => Atom): Audien
     return op(a, b);
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-const primitives: Record<string, Function> = {
+const primitives: Record<string, PrimitiveFn> = {
     // boolean operations
     not: (args: Atom[]) => {
         const [arg] = args;
@@ -240,8 +152,4 @@ function getInEnvBool(name: Atom, env: Environment): boolean | AudienceError {
         return { message: `'${name}' is not a boolean` };
     }
     return val;
-}
-
-function isError(x: Atom | AudienceError): x is AudienceError {
-    return (x as AudienceError).message !== undefined;
 }

--- a/src/audience.ts
+++ b/src/audience.ts
@@ -1,15 +1,31 @@
+//
+// See Audience.md in docs/
+//
+
+/**
+ * Evaluating an audience can yield a runtime error.
+ */
 export type AudienceError = {
     message: string;
 };
 
+/**
+ * The rules syntax is a subset of JSON.
+ */
+export type AST = Atom | List;
 export type Atom = string | number | boolean;
 export type List = Array<List | Atom>;
-export type AST = Atom | List;
 
+/**
+ * The environment is passed in from the outside when evaluating rules
+ */
 export type Environment = {
     attributes: Record<string, Atom>;
 };
 
+/**
+ * Audience contains rules to be evaluated for activating projects.
+ */
 export class Audience {
     ast: AST;
 
@@ -17,6 +33,10 @@ export class Audience {
         this.ast = JSON.parse(json);
     }
 
+    /**
+     * eval interprets the rules in the given environment, and returns true if
+     * the audience matches.
+     */
     eval(env: Environment): boolean | AudienceError {
         const result = this.evalAst(this.ast, env);
 
@@ -31,7 +51,7 @@ export class Audience {
         return result;
     }
 
-    evalAst(ast: AST, env: Environment): Atom | AudienceError {
+    private evalAst(ast: AST, env: Environment): Atom | AudienceError {
         switch (typeof ast) {
             case "number":
                 return ast;
@@ -47,7 +67,7 @@ export class Audience {
         return { message: `cannot evaluate ${ast}` };
     }
 
-    evalApply(head: string, args: List, env: Environment): Atom | AudienceError {
+    private evalApply(head: string, args: List, env: Environment): Atom | AudienceError {
         const prim = primitives[head];
         if (!prim) {
             return { message: `${head} is not a primitive` };

--- a/src/audience.ts
+++ b/src/audience.ts
@@ -3,11 +3,12 @@
 //
 
 import {
-    AST,
     Atom,
     Environment,
-    evalAst,
+    evaluate,
     isError,
+    isList,
+    List,
     parse,
     PrimitiveFn,
     RulesEngineError,
@@ -19,7 +20,7 @@ type AudienceError = RulesEngineError;
  * Audience contains rules to be evaluated for activating projects.
  */
 export class Audience {
-    rules: AST;
+    rules: List;
 
     /**
      * Create a new Audience with the given rules.
@@ -34,6 +35,10 @@ export class Audience {
             throw result;
         }
 
+        if (!isList(result)) {
+            throw { message: "AST root must be a list" };
+        }
+
         this.rules = result;
     }
 
@@ -42,7 +47,7 @@ export class Audience {
      * the audience matches.
      */
     eval(env: Environment): boolean | AudienceError {
-        const result = evalAst(this.rules, env, primitives);
+        const result = evaluate(this.rules, env, primitives);
 
         if (isError(result)) {
             return result;

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,7 +1,7 @@
 import { Audience } from "./audience";
 import { hashInWindow } from "./hash";
 import { Logger } from "./logger";
-import { AST, isError } from "./rules-engine";
+import { List, isError } from "./rules-engine";
 
 export type ProjectState = "paused" | "active";
 
@@ -25,7 +25,7 @@ export type ProjectConfig = {
     name: string;
     variations: VariationConfig[];
     state: ProjectState;
-    audience_rules?: AST;
+    audience_rules?: List;
     audience?: Audience;
 };
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,6 +1,11 @@
+import { Audience } from "./audience";
 import { hashInWindow } from "./hash";
+import { Logger } from "./logger";
+import { AST, isError } from "./rules-engine";
 
 export type ProjectState = "paused" | "active";
+
+export type AudienceAttributes = Record<string, boolean | number | string>;
 
 export enum PrivacyMode {
     DEFAULT = 0,
@@ -20,6 +25,8 @@ export type ProjectConfig = {
     name: string;
     variations: VariationConfig[];
     state: ProjectState;
+    audience_rules?: AST;
+    audience?: Audience;
 };
 
 export type VariationConfig = {
@@ -64,7 +71,43 @@ export function findVariationForVisitor(
     return null;
 }
 
+export function doesAudienceApply(
+    project: ProjectConfig,
+    attributes: AudienceAttributes,
+    logger: Logger,
+): boolean {
+    if (!project.audience) {
+        // no audience setup means always true
+        return true;
+    }
+
+    const result = project.audience.eval({ attributes });
+
+    if (isError(result)) {
+        logger.warn(`audience check failed: ${result.message}`);
+        return false;
+    }
+
+    return result;
+}
+
+export function restoreAudience(cfg: ProjectConfig): void {
+    if (cfg.audience_rules) {
+        // If we refactor the Audience constructor we can avoid this extra stringify, but
+        // since we only construct Project instances on config load it's not performance sensitive.
+        const audienceJSON = JSON.stringify(cfg.audience_rules);
+        cfg.audience = new Audience(audienceJSON);
+    }
+}
+
 export function parseConfigJSON(json: string): SymplifyConfig {
     const BOM = /^\xEF\xBB\xBF/;
-    return JSON.parse(json.trimStart().replace(BOM, ""));
+    const cleanJSON = json.trimStart().replace(BOM, "");
+    const config: SymplifyConfig = JSON.parse(cleanJSON);
+
+    for (const project of config.projects) {
+        restoreAudience(project);
+    }
+
+    return config;
 }

--- a/src/rules-engine.ts
+++ b/src/rules-engine.ts
@@ -1,0 +1,134 @@
+/**
+ * The rules syntax is a subset of JSON.
+ */
+export type AST = Atom | List;
+export type Atom = string | number | boolean;
+export type List = Array<List | Atom>;
+
+/**
+ * Evaluating rules can yield a runtime error.
+ */
+export type RulesEngineError = {
+    message: string;
+};
+
+/**
+ * The environment is passed in from the outside when evaluating rules.
+ */
+export type Environment = {
+    attributes: Record<string, Atom>;
+};
+
+/**
+ * Primitive functions can be applied when evaluating, they can have arguemnts
+ * and have access to the environment.
+ */
+export type PrimitiveFn = (args: Atom[], env: Environment) => Atom | RulesEngineError;
+
+export function parse(rules: string, primitives: string[]): AST | RulesEngineError {
+    let ast: AST;
+    try {
+        ast = JSON.parse(rules);
+    } catch (x) {
+        return { message: "rules syntax error" };
+    }
+
+    try {
+        checkSyntax(ast, primitives);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+        if (isError(e)) {
+            return e;
+        }
+        throw e;
+    }
+
+    return ast;
+}
+
+export function checkSyntax(ast: AST, primitives: string[]): void {
+    switch (typeof ast) {
+        case "object":
+            if (ast instanceof Array) {
+                checkSyntaxInner(ast, primitives);
+            }
+            return;
+    }
+    throw { message: "AST root must be a list" };
+}
+
+function checkSyntaxInner(ast: AST, primitives: string[]): void {
+    switch (typeof ast) {
+        case "number":
+            return;
+        case "string":
+            return;
+        case "boolean":
+            return;
+        case "object":
+            if (ast instanceof Array) {
+                const car = ast[0];
+                if (typeof car != "string") {
+                    throw { message: `can only apply strings, ${car} is not a string` };
+                }
+                if (primitives.indexOf(car) < 0) {
+                    throw { message: `${car} is not a primitive` };
+                }
+                const cdr = ast.slice(1);
+                for (const elem of cdr) {
+                    checkSyntaxInner(elem, primitives);
+                }
+                return;
+            }
+    }
+    throw { message: `rules syntax error at ${JSON.stringify(ast)}` };
+}
+
+export function evalAst(
+    ast: AST,
+    env: Environment,
+    primitives: Record<string, PrimitiveFn>,
+): Atom | RulesEngineError {
+    switch (typeof ast) {
+        case "number":
+            return ast;
+        case "string":
+            return ast;
+        case "boolean":
+            return ast;
+        case "object":
+            if (ast instanceof Array && typeof ast[0] == "string") {
+                return evalApply(ast[0], ast.slice(1), env, primitives);
+            }
+    }
+    return { message: `cannot evaluate ${ast}` };
+}
+
+function evalApply(
+    head: string,
+    args: List,
+    env: Environment,
+    primitives: Record<string, PrimitiveFn>,
+): Atom | RulesEngineError {
+    const prim = primitives[head];
+    if (!prim) {
+        return { message: `${head} is not a primitive` };
+    }
+    try {
+        const evaledArgs: Atom[] = [];
+        for (const arg of args) {
+            const a = evalAst(arg, env, primitives);
+            if (isError(a)) {
+                return a;
+            }
+            evaledArgs.push(a);
+        }
+        return prim(evaledArgs, env);
+    } catch {
+        return { message: `error applying primitive ${head}` };
+    }
+}
+
+export function isError(x: unknown): x is RulesEngineError {
+    return (x as RulesEngineError).message !== undefined;
+}

--- a/src/rules-engine.ts
+++ b/src/rules-engine.ts
@@ -40,7 +40,7 @@ export function parse(rules: string, primitives: string[]): AST | RulesEngineErr
         if (isError(e)) {
             return e;
         }
-        throw e;
+        return { message: `unexpected error checking AST: ${e}` };
     }
 
     return ast;

--- a/test/audience.test.ts
+++ b/test/audience.test.ts
@@ -15,6 +15,13 @@ function testIs(exprJSON: string, expected: Atom | AudienceError) {
     });
 }
 
+describe("Audience validation", () => {
+    expect(() => new Audience("[")).toThrow("rules syntax error");
+    expect(() => new Audience("false")).toThrow("AST root must be a list");
+    expect(() => new Audience('["goober"]')).toThrow("goober is not a primitive");
+    expect(() => new Audience("[true]")).toThrow("can only apply strings");
+});
+
 describe("Audience string primitives", () => {
     testIs('["equals", "", ""]', true);
     testIs('["equals", "foo", ""]', false);

--- a/test/audience.test.ts
+++ b/test/audience.test.ts
@@ -13,7 +13,11 @@ function testIs(
     expected: Atom | AudienceError,
     attributes: Record<string, Atom> = {},
 ) {
-    const desc = `${exprJSON} with ${JSON.stringify(attributes)}  should be ${JSON.stringify(expected)}`;
+    let attrDesc = "";
+    if (0 < Object.keys(attributes).length) {
+        attrDesc = ` with ${JSON.stringify(attributes)}`;
+    }
+    const desc = `${exprJSON}${attrDesc} should be ${JSON.stringify(expected)}`;
     test(desc, () => {
         expect(evalAudience(exprJSON, attributes)).toStrictEqual(expected);
     });

--- a/test/audience.test.ts
+++ b/test/audience.test.ts
@@ -1,0 +1,101 @@
+import { Atom, Audience, AudienceError } from "../src/audience";
+
+function evalAudience(json: string): boolean | AudienceError {
+    return new Audience(json).eval({ attributes: {} });
+}
+
+function error(message: string): AudienceError {
+    return { message };
+}
+
+function testIs(exprJSON: string, expected: Atom | AudienceError) {
+    const desc = `${exprJSON} should be ${JSON.stringify(expected)}`;
+    test(desc, () => {
+        expect(evalAudience(exprJSON)).toStrictEqual(expected);
+    });
+}
+
+describe("Audience string primitives", () => {
+    testIs('["equals", "", ""]', true);
+    testIs('["equals", "foo", ""]', false);
+    testIs('["equals", "", "bar"]', false);
+    testIs('["equals", "foo", "foo"]', true);
+    testIs('["equals", "foo", "bar"]', false);
+
+    testIs('["contains", "foo", ""]', true);
+    testIs('["contains", "", "foo"]', false);
+    testIs('["contains", "foo", "o"]', true);
+    testIs('["contains", "foo", "a"]', false);
+
+    testIs('["matches", "foo", ""]', true);
+    testIs('["matches", "", "foo"]', false);
+    testIs('["matches", "foo", "(bar|foo)"]', true);
+    testIs('["matches", "foo", "aa*"]', false);
+
+    testIs('["matches", 2, "2"]', error("expected string arguments"));
+    testIs('["equals", "", false]', error("expected string arguments"));
+    testIs('["contains", 4711, 1]', error("expected string arguments"));
+});
+
+describe("Audience number primitives", () => {
+    testIs('["==", 4711, 1337]', false);
+    testIs('["==", 1337, 1337]', true);
+    testIs('["==", 42, 1337]', false);
+
+    testIs('["<", 4711, 1337]', false);
+    testIs('["<", 1337, 1337]', false);
+    testIs('["<", 42, 1337]', true);
+
+    testIs('["<=", 4711, 1337]', false);
+    testIs('["<=", 1337, 1337]', true);
+    testIs('["<=", 42, 1337]', true);
+
+    testIs('[">", 4711, 1337]', true);
+    testIs('[">", 1337, 1337]', false);
+    testIs('[">", 42, 1337]', false);
+
+    testIs('[">=", 4711, 1337]', true);
+    testIs('[">=", 1337, 1337]', true);
+    testIs('[">=", 42, 1337]', false);
+
+    testIs('["==", 2, "2"]', error("expected number arguments"));
+    testIs('["<", "", false]', error("expected number arguments"));
+    testIs('["<=", 1, false]', error("expected number arguments"));
+    testIs('[">", "fo", "ba"]', error("expected number arguments"));
+    testIs('[">=", true, 1]', error("expected number arguments"));
+});
+
+describe("Audience boolean primitives", () => {
+    testIs('["all", true]', true);
+    testIs('["all", true, true, true]', true);
+    testIs('["all"]', true);
+    testIs('["all", false, true, true]', false);
+    testIs('["all", true, false, true]', false);
+    testIs('["all", true, true, false]', false);
+
+    testIs('["any", true, true, true]', true);
+    testIs('["any", true, false, false]', true);
+    testIs('["any", false, true, false]', true);
+    testIs('["any", false, false, true]', true);
+
+    testIs('["any", false, false, false]', false);
+    testIs('["any", false]', false);
+    testIs('["any"]', false);
+
+    testIs('["not", false]', true);
+    testIs('["not", true]', false);
+    testIs('["all", 2, "2"]', error("2 is not a boolean"));
+    testIs('["any", false, "foo"]', error("foo is not a boolean"));
+    testIs('["not", 1]', error("1 is not a boolean"));
+});
+
+describe("Audience nested expressions", () => {
+    testIs('["all", ["all"]]', true);
+    testIs('["all", ["any"]]', false);
+    testIs('["any", ["any"], ["any"], ["all"]]', true);
+    testIs('["any", ["any", ["any", ["all"]]]]', true);
+
+    testIs('["any", ["not", true], ["equals", "foo", "bar"], ["==", 1, 1]]', true);
+    testIs('["any", ["not", false], ["equals", "foo", "bar"], ["==", 1, 2]]', true);
+    testIs('["any", ["not", true], ["equals", "foo", "foo"], ["==", 1, 2]]', true);
+});

--- a/test/audience.test.ts
+++ b/test/audience.test.ts
@@ -1,155 +1,100 @@
-import { Atom, Audience, AudienceError } from "../src/audience";
+import fs from "fs";
 
-function evalAudience(json: string, attributes: Record<string, Atom>): boolean | AudienceError {
-    return new Audience(json).eval({ attributes });
-}
-
-function error(message: string): AudienceError {
-    return { message };
-}
-
-function testIs(
-    exprJSON: string,
-    expected: Atom | AudienceError,
-    attributes: Record<string, Atom> = {},
-) {
-    let attrDesc = "";
-    if (0 < Object.keys(attributes).length) {
-        attrDesc = ` with ${JSON.stringify(attributes)}`;
-    }
-    const desc = `${exprJSON}${attrDesc} should be ${JSON.stringify(expected)}`;
-    test(desc, () => {
-        expect(evalAudience(exprJSON, attributes)).toStrictEqual(expected);
-    });
-}
+import { Audience } from "../src/audience";
 
 describe("Audience validation", () => {
-    expect(() => new Audience("[")).toThrow("rules syntax error");
-    expect(() => new Audience("false")).toThrow("AST root must be a list");
-    expect(() => new Audience('["goober"]')).toThrow("goober is not a primitive");
-    expect(() => new Audience("[true]")).toThrow("can only apply strings");
+    const testData = JSON.parse(fs.readFileSync("test/audience_validation_spec.json").toString());
+
+    for (const s of testData) {
+        if (s.skip) {
+            console.log(`skipping test '${s.suite_name}' (because ${s.skip})`);
+            continue;
+        }
+
+        describe(s.suite_name, () => {
+            for (const i in s.test_cases) {
+                const t = s.test_cases[i];
+                const desc = `expression JSON '${t.audience_string}' should error with '${t.expect_error}'`;
+                test(desc, () => {
+                    expect(() => new Audience(t.audience_string)).toThrow(t.expect_error);
+                });
+            }
+        });
+    }
 });
 
-describe("Audience string primitives", () => {
-    testIs('["equals", "", ""]', true);
-    testIs('["equals", "foo", ""]', false);
-    testIs('["equals", "", "bar"]', false);
-    testIs('["equals", "foo", "foo"]', true);
-    testIs('["equals", "foo", "bar"]', false);
+/**
+ * These test cases are defined in JSON to enable portable repeatable testing for multiple SDKs.
+ */
+describe("Audience expression compatibility tests", () => {
+    const testData = JSON.parse(fs.readFileSync("test/audience_spec.json").toString());
 
-    testIs('["contains", "foo", ""]', true);
-    testIs('["contains", "", "foo"]', false);
-    testIs('["contains", "foo", "o"]', true);
-    testIs('["contains", "foo", "a"]', false);
+    for (const s of testData) {
+        if (s.skip) {
+            console.log(`skipping test '${s.suite_name}' (because ${s.skip})`);
+            continue;
+        }
 
-    testIs('["matches", "foo", ""]', true);
-    testIs('["matches", "", "foo"]', false);
-    testIs('["matches", "foo", "(bar|foo)"]', true);
-    testIs('["matches", "foo", "aa*"]', false);
+        describe(s.suite_name, () => {
+            for (const i in s.test_cases) {
+                const t = s.test_cases[i];
+                const audienceJSON = JSON.stringify(t.audience_json);
+                const desc = t.expect_error
+                    ? `expression ${audienceJSON} should error with '${t.expect_error}'`
+                    : `expression ${audienceJSON} should be ${t.expect_result}`;
+                test(desc, () => {
+                    const audience = new Audience(audienceJSON);
+                    const actual = audience.eval({ attributes: {} });
 
-    testIs('["matches", 2, "2"]', error("expected string arguments"));
-    testIs('["equals", "", false]', error("expected string arguments"));
-    testIs('["contains", 4711, 1]', error("expected string arguments"));
+                    if (t.expect_error) {
+                        if (typeof actual === "boolean") {
+                            fail("expected error, got some result");
+                        }
+                        expect(actual.message).toBe(t.expect_error);
+                    } else {
+                        expect(actual).toBe(t.expect_result);
+                    }
+                });
+            }
+        });
+    }
 });
 
-describe("Audience number primitives", () => {
-    testIs('["==", 4711, 1337]', false);
-    testIs('["==", 1337, 1337]', true);
-    testIs('["==", 42, 1337]', false);
+/**
+ * These test cases are defined in JSON to enable portable repeatable testing for multiple SDKs.
+ */
+describe("Audience attributes compatibility tests", () => {
+    const testData = JSON.parse(fs.readFileSync("test/audience_attributes_spec.json").toString());
 
-    testIs('["<", 4711, 1337]', false);
-    testIs('["<", 1337, 1337]', false);
-    testIs('["<", 42, 1337]', true);
+    for (const s of testData) {
+        if (s.skip) {
+            console.log(`skipping test '${s.suite_name}' (because ${s.skip})`);
+            continue;
+        }
 
-    testIs('["<=", 4711, 1337]', false);
-    testIs('["<=", 1337, 1337]', true);
-    testIs('["<=", 42, 1337]', true);
+        describe(s.suite_name, () => {
+            const audienceJSON = JSON.stringify(s.audience_json);
+            const audience = new Audience(audienceJSON);
 
-    testIs('[">", 4711, 1337]', true);
-    testIs('[">", 1337, 1337]', false);
-    testIs('[">", 42, 1337]', false);
+            for (const i in s.test_cases) {
+                const t = s.test_cases[i];
+                const attributes = t.attributes;
+                const desc = t.expect_error
+                    ? `attributes ${JSON.stringify(attributes)} should give err '${t.expect_error}'`
+                    : `attributes ${JSON.stringify(attributes)} should give ${t.expect_result}`;
+                test(desc, () => {
+                    const actual = audience.eval({ attributes });
 
-    testIs('[">=", 4711, 1337]', true);
-    testIs('[">=", 1337, 1337]', true);
-    testIs('[">=", 42, 1337]', false);
-
-    testIs('["==", 2, "2"]', error("expected number arguments"));
-    testIs('["<", "", false]', error("expected number arguments"));
-    testIs('["<=", 1, false]', error("expected number arguments"));
-    testIs('[">", "fo", "ba"]', error("expected number arguments"));
-    testIs('[">=", true, 1]', error("expected number arguments"));
-});
-
-describe("Audience boolean primitives", () => {
-    testIs('["all", true]', true);
-    testIs('["all", true, true, true]', true);
-    testIs('["all"]', true);
-    testIs('["all", false, true, true]', false);
-    testIs('["all", true, false, true]', false);
-    testIs('["all", true, true, false]', false);
-
-    testIs('["any", true, true, true]', true);
-    testIs('["any", true, false, false]', true);
-    testIs('["any", false, true, false]', true);
-    testIs('["any", false, false, true]', true);
-
-    testIs('["any", false, false, false]', false);
-    testIs('["any", false]', false);
-    testIs('["any"]', false);
-
-    testIs('["not", false]', true);
-    testIs('["not", true]', false);
-    testIs('["all", 2, "2"]', error("2 is not a boolean"));
-    testIs('["any", false, "foo"]', error("foo is not a boolean"));
-    testIs('["not", 1]', error("1 is not a boolean"));
-});
-
-describe("Audience nested expressions", () => {
-    testIs('["all", ["all"]]', true);
-    testIs('["all", ["any"]]', false);
-    testIs('["any", ["any"], ["any"], ["all"]]', true);
-    testIs('["any", ["any", ["any", ["all"]]]]', true);
-
-    testIs('["any", ["not", true], ["equals", "foo", "bar"], ["==", 1, 1]]', true);
-    testIs('["any", ["not", false], ["equals", "foo", "bar"], ["==", 1, 2]]', true);
-    testIs('["any", ["not", true], ["equals", "foo", "foo"], ["==", 1, 2]]', true);
-});
-
-describe("Audience docs example expressions", () => {
-    const allExpr = `
-        ["all",
-          [">=", ["number-attribute", "bonusPoints"], 1000],
-          ["contains", ["string-attribute", "urlPath"], "contact"],
-          ["equals", ["string-attribute", "country"], "Sweden"]]`;
-    const anyExpr = `
-        ["any",
-          ["bool-attribute", "preview"],
-          ["equals", ["string-attribute", "environment"], "staging"]]`;
-
-    testIs(allExpr, true, { bonusPoints: 1000, urlPath: "/contact", country: "Sweden" });
-    testIs(allExpr, false, { bonusPoints: 999, urlPath: "/contact", country: "Sweden" });
-    testIs(allExpr, false, { bonusPoints: 1000, urlPath: "/contact", country: "Norway" });
-    testIs(allExpr, false, { bonusPoints: 1000, urlPath: "/home", country: "Sweden" });
-
-    testIs(allExpr, error("'bonusPoints' is not a number"), {
-        urlPath: "/home",
-        country: "Sweden",
-    });
-    testIs(allExpr, error("'urlPath' is not a string"), {
-        bonusPoints: 0,
-        country: "xyz",
-    });
-    testIs(allExpr, error("'country' is not a string"), {
-        bonusPoints: 0,
-        urlPath: "/home",
-    });
-
-    testIs(anyExpr, true, { preview: true, environment: "production" });
-    testIs(anyExpr, true, { preview: false, environment: "staging" });
-    testIs(anyExpr, error("'preview' is not a boolean"), {
-        environment: "staging",
-    });
-    testIs(anyExpr, error("'environment' is not a string"), {
-        preview: true,
-    });
+                    if (t.expect_error) {
+                        if (typeof actual === "boolean") {
+                            fail("expected error, got some result");
+                        }
+                        expect(actual.message).toBe(t.expect_error);
+                    } else {
+                        expect(actual).toBe(t.expect_result);
+                    }
+                });
+            }
+        });
+    }
 });

--- a/test/audience_attributes_spec.json
+++ b/test/audience_attributes_spec.json
@@ -1,0 +1,146 @@
+[
+  {
+    "suite_name": "attribute getters",
+    "audience_json": [
+      "any",
+      ["equals", ["string-attribute", "foo"], "bar"],
+      ["==", ["number-attribute", "number"], 4711],
+      ["bool-attribute", "yes"]
+    ],
+    "test_cases": [
+      {
+        "attributes": {
+          "foo": "bar",
+          "number": 4711,
+          "yes": true
+        },
+        "expect_result": true
+      },
+      {
+        "attributes": {
+          "foo": "bar",
+          "number": 0,
+          "yes": false
+        },
+        "expect_result": true
+      },
+      {
+        "attributes": {
+          "foo": "",
+          "number": 4711,
+          "yes": false
+        },
+        "expect_result": true
+      },
+      {
+        "attributes": {
+          "foo": "",
+          "number": 0,
+          "yes": true
+        },
+        "expect_result": true
+      },
+      {
+        "attributes": {},
+        "expect_error": "'foo' is not a string"
+      },
+      {
+        "attributes": {
+          "foo": ""
+        },
+        "expect_error": "'number' is not a number"
+      },
+      {
+        "attributes": {
+          "foo": "",
+          "number": 0
+        },
+        "expect_error": "'yes' is not a boolean"
+      }
+    ]
+  },
+  {
+    "suite_name": "docs example: 'any'",
+    "audience_json": [
+      "any",
+      ["bool-attribute", "preview"],
+      ["equals", ["string-attribute", "environment"], "staging"]
+    ],
+    "test_cases": [
+      {
+        "attributes": { "preview": true, "environment": "production" },
+        "expect_result": true
+      },
+      {
+        "attributes": { "preview": false, "environment": "staging" },
+        "expect_result": true
+      },
+      {
+        "attributes": { "preview": false, "environment": "production" },
+        "expect_result": false
+      },
+
+      {
+        "attributes": { "environment": "production" },
+        "expect_error": "'preview' is not a boolean"
+      },
+      {
+        "attributes": { "preview": false },
+        "expect_error": "'environment' is not a string"
+      }
+    ]
+  },
+  {
+    "suite_name": "docs example: 'all'",
+    "audience_json": [
+      "all",
+      [">=", ["number-attribute", "bonusPoints"], 1000],
+      ["contains", ["string-attribute", "urlPath"], "contact"],
+      ["equals", ["string-attribute", "country"], "Sweden"]
+    ],
+    "test_cases": [
+      {
+        "attributes": { "bonusPoints": 1000, "urlPath": "/contact", "country": "Sweden" },
+        "expect_result": true
+      },
+      {
+        "attributes": { "bonusPoints": 999, "urlPath": "/contact", "country": "Sweden" },
+        "expect_result": false
+      },
+      {
+        "attributes": { "bonusPoints": 1000, "urlPath": "/contact", "country": "Norway" },
+        "expect_result": false
+      },
+      {
+        "attributes": { "bonusPoints": 1000, "urlPath": "/home", "country": "Sweden" },
+        "expect_result": false
+      },
+
+      {
+        "attributes": {},
+        "expect_error": "'bonusPoints' is not a number"
+      },
+      {
+        "attributes": {
+          "urlPath": "/home",
+          "country": "Sweden"
+        },
+        "expect_error": "'bonusPoints' is not a number"
+      },
+      {
+        "attributes": {
+          "bonusPoints": 1000,
+          "country": "Sweden"
+        },
+        "expect_error": "'urlPath' is not a string"
+      },
+      {
+        "attributes": {
+          "bonusPoints": 1000,
+          "urlPath": "/home"
+        },
+        "expect_error": "'country' is not a string"
+      }
+    ]
+  }
+]

--- a/test/audience_spec.json
+++ b/test/audience_spec.json
@@ -1,0 +1,101 @@
+[
+  {
+    "suite_name": "string primitives",
+    "test_cases": [
+      { "audience_json": ["equals", "", ""], "expect_result": true },
+      { "audience_json": ["equals", "foo", ""], "expect_result": false },
+      { "audience_json": ["equals", "", "bar"], "expect_result": false },
+      { "audience_json": ["equals", "foo", "foo"], "expect_result": true },
+      { "audience_json": ["equals", "foo", "bar"], "expect_result": false },
+      { "audience_json": ["contains", "foo", ""], "expect_result": true },
+      { "audience_json": ["contains", "", "foo"], "expect_result": false },
+      { "audience_json": ["contains", "foo", "o"], "expect_result": true },
+      { "audience_json": ["contains", "foo", "a"], "expect_result": false },
+      { "audience_json": ["matches", "foo", ""], "expect_result": true },
+      { "audience_json": ["matches", "", "foo"], "expect_result": false },
+      { "audience_json": ["matches", "foo", "(bar|foo)"], "expect_result": true },
+      { "audience_json": ["matches", "foo", "aa*"], "expect_result": false },
+
+      { "audience_json": ["matches", 2, "2"], "expect_error": "expected string arguments" },
+      { "audience_json": ["equals", "", false], "expect_error": "expected string arguments" },
+      { "audience_json": ["contains", 4711, 1], "expect_error": "expected string arguments" }
+    ]
+  },
+  {
+    "suite_name": "number primitives",
+    "test_cases": [
+      { "audience_json": ["==", 4711, 1337], "expect_result": false },
+      { "audience_json": ["==", 1337, 1337], "expect_result": true },
+      { "audience_json": ["==", 42, 1337], "expect_result": false },
+
+      { "audience_json": ["<", 4711, 1337], "expect_result": false },
+      { "audience_json": ["<", 1337, 1337], "expect_result": false },
+      { "audience_json": ["<", 42, 1337], "expect_result": true },
+
+      { "audience_json": ["<=", 4711, 1337], "expect_result": false },
+      { "audience_json": ["<=", 1337, 1337], "expect_result": true },
+      { "audience_json": ["<=", 42, 1337], "expect_result": true },
+
+      { "audience_json": [">", 4711, 1337], "expect_result": true },
+      { "audience_json": [">", 1337, 1337], "expect_result": false },
+      { "audience_json": [">", 42, 1337], "expect_result": false },
+
+      { "audience_json": [">=", 4711, 1337], "expect_result": true },
+      { "audience_json": [">=", 1337, 1337], "expect_result": true },
+      { "audience_json": [">=", 42, 1337], "expect_result": false },
+
+      { "audience_json": ["==", 2, "2"], "expect_error": "expected number arguments" },
+      { "audience_json": ["<", "", false], "expect_error": "expected number arguments" },
+      { "audience_json": ["<=", 1, false], "expect_error": "expected number arguments" },
+      { "audience_json": [">", "fo", "ba"], "expect_error": "expected number arguments" },
+      { "audience_json": [">=", true, 1], "expect_error": "expected number arguments" }
+    ]
+  },
+  {
+    "suite_name": "boolean primitives",
+    "test_cases": [
+      { "audience_json": ["all"], "expect_result": true },
+      { "audience_json": ["all", true], "expect_result": true },
+      { "audience_json": ["all", true, true, true], "expect_result": true },
+      { "audience_json": ["all", false, true, true], "expect_result": false },
+      { "audience_json": ["all", true, false, true], "expect_result": false },
+      { "audience_json": ["all", true, true, false], "expect_result": false },
+
+      { "audience_json": ["any"], "expect_result": false },
+      { "audience_json": ["any", false], "expect_result": false },
+      { "audience_json": ["any", true, true, true], "expect_result": true },
+      { "audience_json": ["any", true, false, false], "expect_result": true },
+      { "audience_json": ["any", false, true, false], "expect_result": true },
+      { "audience_json": ["any", false, false, true], "expect_result": true },
+      { "audience_json": ["any", false, false, false], "expect_result": false },
+
+      { "audience_json": ["not", false], "expect_result": true },
+      { "audience_json": ["not", true], "expect_result": false },
+
+      { "audience_json": ["all", 2, "2"], "expect_error": "2 is not a boolean" },
+      { "audience_json": ["any", false, "foo"], "expect_error": "foo is not a boolean" },
+      { "audience_json": ["not", 1], "expect_error": "1 is not a boolean" }
+    ]
+  },
+  {
+    "suite_name": "nested expressions",
+    "test_cases": [
+      { "audience_json": ["all", ["all"]], "expect_result": true },
+      { "audience_json": ["all", ["any"]], "expect_result": false },
+      { "audience_json": ["any", ["any"], ["any"], ["all"]], "expect_result": true },
+      { "audience_json": ["any", ["any", ["any", ["all"]]]], "expect_result": true },
+      {
+        "audience_json": ["any", ["not", true], ["equals", "foo", "bar"], ["==", 1, 1]],
+        "expect_result": true
+      },
+      {
+        "audience_json": ["any", ["not", false], ["equals", "foo", "bar"], ["==", 1, 2]],
+        "expect_result": true
+      },
+      {
+        "audience_json": ["any", ["not", true], ["equals", "foo", "foo"], ["==", 1, 2]],
+        "expect_result": true
+      }
+    ]
+  }
+]

--- a/test/audience_validation_spec.json
+++ b/test/audience_validation_spec.json
@@ -11,10 +11,6 @@
         "expect_error": "AST root must be a list"
       },
       {
-        "audience_string": "[\"goober\"]",
-        "expect_error": "goober is not a primitive"
-      },
-      {
         "audience_string": "[true]",
         "expect_error": "can only apply strings"
       }

--- a/test/audience_validation_spec.json
+++ b/test/audience_validation_spec.json
@@ -1,0 +1,23 @@
+[
+  {
+    "suite_name": "static expression validation",
+    "test_cases": [
+      {
+        "audience_string": "[",
+        "expect_error": "rules syntax error"
+      },
+      {
+        "audience_string": "false",
+        "expect_error": "AST root must be a list"
+      },
+      {
+        "audience_string": "[\"goober\"]",
+        "expect_error": "goober is not a primitive"
+      },
+      {
+        "audience_string": "[true]",
+        "expect_error": "can only apply strings"
+      }
+    ]
+  }
+]

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -20,12 +20,17 @@ describe("SymplifySDK client", () => {
 
             const sdk = new SymplifySDK(t.website_id, { httpGET });
             await sdk.ready;
-            const variation = sdk.findVariation(t.test_project_name, cookies);
+            const variation = sdk.findVariation(
+                t.test_project_name,
+                cookies,
+                t.audience_attributes,
+            );
             sdk.stop();
 
             const sgCookies = JSON.parse(cookies.get("sg_cookies") || "{}");
 
-            for (const [keypath, expected] of Object.entries(t.expect_sg_cookie_properties_match)) {
+            const checkCookieProps = t.expect_sg_cookie_properties_match || {};
+            for (const [keypath, expected] of Object.entries(checkCookieProps)) {
                 const leaf = keypath.split("/").reduce((acc, p) => (acc || {})[p], sgCookies);
                 if (typeof expected == "string") {
                     const reCookie = new RegExp(expected);

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -1,4 +1,6 @@
-import { parseConfigJSON } from "../src/project";
+import { NullLogger } from "../src/logger";
+import { doesAudienceApply, parseConfigJSON, ProjectConfig, restoreAudience } from "../src/project";
+import { AST } from "../src/rules-engine";
 
 describe("SymplifyConfig", () => {
     test("can parse plain JSON", () => {
@@ -11,6 +13,36 @@ describe("SymplifyConfig", () => {
 
     test("can parse JSON with a UTF-16 BOM", () => {
         expect(parseConfigJSON(CONFIG_JSON_WITH_UTF16_BOM).updated).toBe(1648466732);
+    });
+});
+
+describe("ProjectConfig", () => {
+    test("can restore audience from rules", () => {
+        const cfg = testConfig(["all"]);
+        expect(cfg.audience).toBeUndefined();
+        restoreAudience(cfg);
+        expect(cfg.audience).toBeDefined();
+    });
+
+    test("can tell if audience is true", () => {
+        const cfg = testConfig(["all"]);
+        restoreAudience(cfg);
+        const result = doesAudienceApply(cfg, {}, new NullLogger());
+        expect(result).toBe(true);
+    });
+
+    test("can tell if audience is false", () => {
+        const cfg = testConfig(["any"]);
+        restoreAudience(cfg);
+        const result = doesAudienceApply(cfg, {}, new NullLogger());
+        expect(result).toBe(false);
+    });
+
+    test("treats no audience as true", () => {
+        const cfg = testConfig();
+        restoreAudience(cfg);
+        const result = doesAudienceApply(cfg, {}, new NullLogger());
+        expect(result).toBe(true);
     });
 });
 
@@ -44,3 +76,13 @@ const CONFIG_JSON = `{
 const CONFIG_JSON_WITH_UTF8_BOM = "\xEF\xBB\xBF" + CONFIG_JSON;
 
 const CONFIG_JSON_WITH_UTF16_BOM = "\uFEFF" + CONFIG_JSON;
+
+function testConfig(audience_rules?: AST): ProjectConfig {
+    return {
+        id: 9999,
+        name: "test project please ignore",
+        state: "active",
+        audience_rules,
+        variations: [{ id: 99991, name: "Original", state: "active", weight: 100 }],
+    };
+}

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -1,6 +1,6 @@
 import { NullLogger } from "../src/logger";
 import { doesAudienceApply, parseConfigJSON, ProjectConfig, restoreAudience } from "../src/project";
-import { AST } from "../src/rules-engine";
+import { List } from "../src/rules-engine";
 
 describe("SymplifyConfig", () => {
     test("can parse plain JSON", () => {
@@ -77,7 +77,7 @@ const CONFIG_JSON_WITH_UTF8_BOM = "\xEF\xBB\xBF" + CONFIG_JSON;
 
 const CONFIG_JSON_WITH_UTF16_BOM = "\uFEFF" + CONFIG_JSON;
 
-function testConfig(audience_rules?: AST): ProjectConfig {
+function testConfig(audience_rules?: List): ProjectConfig {
     return {
         id: 9999,
         name: "test project please ignore",

--- a/test/sdk_config.json
+++ b/test/sdk_config.json
@@ -38,6 +38,15 @@
         { "id": 10042, "name": "Variation 1", "weight": 0, "state": "paused" }
       ],
       "state": "paused"
+    },
+    {
+      "id": 1005,
+      "name": "custom audience",
+      "audience_rules": ["equals", ["string-attribute", "foo"], "bar"],
+      "variations": [
+        { "id": 10051, "name": "Original", "weight": 100, "state": "active" }
+      ],
+      "state": "active"
     }
   ]
 }

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -108,8 +108,7 @@
       "sg_cookies": "{%2210001%22:{%221003%22:[10032]%2C%221003_ch%22:1%2C%22aud_p%22:[1003]%2C%22visid%22:%22a_visitor%22}%2C%22_g%22:1}"
     },
     "test_project_name": "no allocations",
-    "expect_variation_match": "Variation 1",
-    "expect_sg_cookie_properties_match": {}
+    "expect_variation_match": "Variation 1"
   },
   {
     "test_name": "persist null allocation",
@@ -129,8 +128,7 @@
       "sg_cookies": "{%2210001%22:{%221001_ch%22:-1%2C%22visid%22:%22foobar%22}%2C%22_g%22:1}"
     },
     "test_project_name": "test project",
-    "expect_variation_match": null,
-    "expect_sg_cookie_properties_match": {}
+    "expect_variation_match": null
   },
   {
     "test_name": "cookie allocated but inactive project",
@@ -140,8 +138,7 @@
       "sg_cookies": "{%2210001%22:{%221004%22:[10042]%2C%221004_ch%22:1%2C%22aud_p%22:[1004]%2C%22visid%22:%22a_visitor%22}%2C%22_g%22:1}"
     },
     "test_project_name": "paused project",
-    "expect_variation_match": null,
-    "expect_sg_cookie_properties_match": {}
+    "expect_variation_match": null
   },
   {
     "test_name": "bail out if privacy mode 2 and no opt-in",
@@ -168,5 +165,25 @@
       "10001/1001": [10013],
       "10001/aud_p": [1001]
     }
+  },
+  {
+    "test_name": "false audience gives no variation",
+    "sdk_config": "sdk_config.json",
+    "website_id": "10001",
+    "test_project_name": "custom audience",
+    "audience_attributes": {
+        "foo": "baz"
+    },
+    "expect_variation_match": null
+  },
+  {
+    "test_name": "true audience gives a variation",
+    "sdk_config": "sdk_config.json",
+    "website_id": "10001",
+    "test_project_name": "custom audience",
+    "audience_attributes": {
+        "foo": "bar"
+    },
+    "expect_variation_match": "Original"
   }
 ]


### PR DESCRIPTION
Why?
====

See the added docs: docs/Audiences.md

This PR adds:

* the rules engine
* the custom audience code using the rules engine
* an example site using a custom audience

The PR is quite big, but hopefully not as big as it first appears: 1500 lines is package-lock.json, 250 lines is benchmarking, 130 lines is example code, 150 lines is documentation.

400 lines of changes are new tests, even if they also require reviewing, of course. So there's about 500 lines of new logic in the PR.