### PR TITLE
Fix cookie jar encoding and expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Fixed
+- removed URI codec from cookie jar (should be handled outside SDK)
 - windowed hash function was not rounding correctly, add `ceil` call for compatibility
 ### Changed
+- add cookie expiry support
 - improved compatibility test suite
 - improved documentation
 

--- a/examples/hello-express/index.js
+++ b/examples/hello-express/index.js
@@ -24,7 +24,11 @@ const sst = new sstsdk(websiteID, overrides);
 function cookieJar(req, res) {
     return {
         get: (name) => req.cookies[name],
-        set: (name, value) => res.cookie(name, value),
+        set: (name, value, expiresInDays) => {
+            const expiresInMillis = expiresInDays * 24 * 3600 * 1000;
+            const expires = new Date(Date.now() + expiresInMillis);
+            res.cookie(name, value, { expires });
+        },
     }
 }
 
@@ -51,6 +55,17 @@ app.get('/products/:sku', (req, res) => {
     res.send(`
         <h2> ${req.params.sku} </h2>
         <p> Price: $10${discounts.length == 0 ? '' : discounts.map(d => `, <span class="rebate">${d * 100}% off</span>`)} </p>
+    `);
+})
+
+app.get('/', (req, res) => {
+    const productCatalog = [1, 2, 3, 4, 5];
+
+    res.send(`
+        <h1> Fake Webshop </h1>
+        <ul>
+            ${productCatalog.map(sku => `<li><a href="/products/${sku}">product ${sku}</a></li>`).join('')}
+        </ul>
     `);
 })
 

--- a/examples/page-variations/app.js
+++ b/examples/page-variations/app.js
@@ -28,7 +28,11 @@ const sst = new sstsdk(websiteID, overrides);
 function cookieJar(req, res) {
     return {
         get: (name) => req.cookies[name],
-        set: (name, value) => res.cookie(name, value),
+        set: (name, value, expiresInDays) => {
+            const expiresInMillis = expiresInDays * 24 * 3600 * 1000;
+            const expires = new Date(Date.now() + expiresInMillis);
+            res.cookie(name, value, { expires });
+        },
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@symplify-conversion/sst-sdk-nodejs",
-  "version": "0.1.1-dev",
+  "version": "0.3.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@symplify-conversion/sst-sdk-nodejs",
-      "version": "0.1.1-dev",
+      "version": "0.3.0-dev",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@symplify-conversion/sst-sdk-nodejs",
-  "version": "0.2.1-dev",
+  "version": "0.3.0-dev",
   "description": "This is the Node.js implementation of the Symplify Server-Side Testing SDK.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,11 +1,21 @@
 import { ProjectConfig, VariationConfig } from "./project";
 
 export type CookieReader = {
+    /**
+     * Get the HTTP cookie from the current request with the given name.
+     * The result should be URL decoded from the browser request.
+     */
     get: (name: string) => string;
 };
 
 export type CookieWriter = {
-    set: (name: string, value: string) => void;
+    /**
+     * Set the HTTP cookie for the current response, with the given name, the given value.
+     * The expires field of the cookie must be `expireInDays` days from now.
+     * The domain field of the cookie should be the domain you run your test projects on.
+     * The cookie value should be URL encoded before reaching the browser.
+     */
+    set: (name: string, value: string, expireInDays: number) => void;
 };
 
 export type CookieJar = CookieReader & CookieWriter;
@@ -22,11 +32,11 @@ export class JSONCookieCodec {
         if (!rawCookie) {
             return null;
         }
-        return JSON.parse(decodeURIComponent(rawCookie));
+        return JSON.parse(rawCookie);
     }
 
     set(name: string, value: unknown) {
-        this.underlying.set(name, encodeURIComponent(JSON.stringify(value)));
+        this.underlying.set(name, JSON.stringify(value), 90);
     }
 }
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -15,7 +15,7 @@ describe("SymplifySDK client", () => {
             const configJSON = fs.readFileSync("test/" + t.sdk_config).toString();
             const httpGET = constantHTTP(configJSON);
             for (const [name, value] of Object.entries(t.cookies || {})) {
-                cookies.set(name, "" + value);
+                cookies.set(name, decodeURIComponent("" + value), 90);
             }
 
             const sdk = new SymplifySDK(t.website_id, { httpGET });
@@ -23,7 +23,7 @@ describe("SymplifySDK client", () => {
             const variation = sdk.findVariation(t.test_project_name, cookies);
             sdk.stop();
 
-            const sgCookies = JSON.parse(decodeURIComponent(cookies.get("sg_cookies") || "{}"));
+            const sgCookies = JSON.parse(cookies.get("sg_cookies") || "{}");
 
             for (const [keypath, expected] of Object.entries(t.expect_sg_cookie_properties_match)) {
                 const leaf = keypath.split("/").reduce((acc, p) => (acc || {})[p], sgCookies);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -2,12 +2,19 @@ import { randomUUID } from "crypto";
 import { CookieJar } from "../src/cookies";
 import { findVariationForVisitor, ProjectConfig } from "../src/project";
 
-export function makeCookieJar(): CookieJar {
+type TestCookieJar = CookieJar & { getExpiresIn: (key: string) => number };
+
+export function makeCookieJar(): TestCookieJar {
     const cookies: Record<string, string> = {};
+    const expiresIn: Record<string, number> = {};
 
     return {
         get: (key: string) => cookies[key],
-        set: (key: string, val: string) => (cookies[key] = val),
+        set: (key: string, val: string, expireInDays: number) => {
+            cookies[key] = val;
+            expiresIn[key] = expireInDays;
+        },
+        getExpiresIn: (key: string) => expiresIn[key],
     };
 }
 

--- a/test/visitor.test.ts
+++ b/test/visitor.test.ts
@@ -33,7 +33,11 @@ describe("ensureVisitorID", () => {
 
         // eslint-disable-next-line prettier/prettier
         const rawCookie = "{%2210001%22:{%22100000002%22:[300001]%2C%22100000001%22:[300002]%2C%22100000002_ch%22:1%2C%22100000001_ch%22:1%2C%22lv%22:1650967549303%2C%22rf%22:%22%22%2C%22pv%22:2%2C%22pv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22tv%22:2%2C%22tv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22aud_p%22:[100000002%2C100000001]%2C%22visid%22:%2278ac2972-de5f-4262-bfdb-7296eb132a94%22%2C%22commid%22:%221be9f08d-c36c-4bce-b157-e057e050027c%22}%2C%22_g%22:1}";
-        cookies.set(JSON_COOKIE_NAME, rawCookie);
+        // The web server/framework should do this decoding, but this test code
+        // is not running there and we wanted to keep `rawCookie` an actual copy
+        // paste from production in this test.
+        const cookie = decodeURIComponent(rawCookie);
+        cookies.set(JSON_COOKIE_NAME, cookie, 90);
         const siteData = new WebsiteData(testWebsiteID, cookies);
 
         const returnedID = ensureVisitorID(siteData, generateConstantID("don't use this"));


### PR DESCRIPTION
Problems
=======

1. The cookie jar code assumes it needs to encode and decode JSON cookies fot frontend compatibility. This does not play nicely with all web frameworks (e.g. the `cookie-parser` middleware for Express encodes and decodes cookie values).

2. We don't set any expiry time on the cookie.

Solution
======

Refactor `JSONCookieCodec` to stop taking responsibility for encoding/decoding, update test suite and examples to match.

Add new parameter `expireInDays` to the `CookieWriter` `set` function. Document the `CookieJar` interface better.