### PR TITLE
Add project preview feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- project preview support (see docs)
 
 ## [0.4.0] - 2022-08-12
 ### Added

--- a/docs/Previewing.md
+++ b/docs/Previewing.md
@@ -17,6 +17,8 @@ Features
 
 * in preview mode, a test will not track any goals
 
+* when previewing, you can debug audience rules, seeing the results of subexpressions
+
 How to use it
 =============
 
@@ -38,10 +40,16 @@ The `js-sdk` frontend is aware of the preview status, it will prevent goal
 tracking etc. and expose some extra information about the allocation and
 audience calculation.
 
+The project audience when previewing will be "traced" by the server running the
+SDK, annotating the rules expression with results of sub-expressions and share
+this trace back with the requesting browser via a cookie ("sg_audience_trace").
+
 Security
 ========
 
 The purpose of the preview feature is to let you double-check if a test is going
-to work before activating it. It is not meant to hide the test project from a
-potential attacker. As such, the implementation described above is only there to
-prevent visitors from mistakenly enabling a project preview.
+to work and how it will look before activating it. It is not meant to hide
+project configurations from any potential attacker.
+
+Since the preview shows the results of subexpressions in any project custom
+audience rules, do not use any sensitive information in audience rules. 

--- a/docs/Previewing.md
+++ b/docs/Previewing.md
@@ -1,0 +1,43 @@
+Preview Mode
+============
+
+In order to safely verify that a server-side test is working in production as
+you want it to, it's possible to configure the project for "preview" mode. Even
+if you have a separate staging environemnt, you might want to double check a
+test in production before enabling it for all visitors.
+
+Features
+========
+
+* a test which is not active can safely be added to your backend code first
+
+* previewing or activating does not require any changes in your backend code
+
+* when previewing, you can select the variation you want to see
+
+* in preview mode, a test will not track any goals
+
+How to use it
+=============
+
+Open the SST project for preview as per usual. Select the variation you want to see. You can copy the URL in your location bar to share with others who need to preview.
+
+How it works
+============
+
+Opening in preview mode sets the `"pmr"` property in the website object in the
+`sg_cookies` JSON cookie to the ID of the previewed project. The ID of the
+previewed variation is written next to it under the key `"pmv”`. The SST SDK
+when checking a project for variation allocation will always check the preview
+status first. If a visitor is previewing a project variation, no allocation
+calculation is performed, but the persistence works as usual. The `js-sdk`
+frontend is aware of the preview status, it will prevent goal tracking etc. and
+expose some extra information about the allocation and audience calculation.
+
+Security
+========
+
+The purpose of the preview feature is to let you double-check if a test is going
+to work before activating it. It is not meant to hide the test project from a
+potential attacker. As such, the implementation described above is only there to
+prevent visitors from mistakenly enabling a project preview.

--- a/docs/Previewing.md
+++ b/docs/Previewing.md
@@ -27,12 +27,16 @@ How it works
 
 Opening in preview mode sets the `"pmr"` property in the website object in the
 `sg_cookies` JSON cookie to the ID of the previewed project. The ID of the
-previewed variation is written next to it under the key `"pmv”`. The SST SDK
-when checking a project for variation allocation will always check the preview
-status first. If a visitor is previewing a project variation, no allocation
-calculation is performed, but the persistence works as usual. The `js-sdk`
-frontend is aware of the preview status, it will prevent goal tracking etc. and
-expose some extra information about the allocation and audience calculation.
+previewed variation is written next to it under the key `"pmv”`.
+
+The SST SDK when checking a project for variation allocation will always check
+the preview status first. If a visitor is previewing a project variation, no
+allocation calculation is performed (the preview status overrides it), but the
+allocation persistence works as usual.
+
+The `js-sdk` frontend is aware of the preview status, it will prevent goal
+tracking etc. and expose some extra information about the allocation and
+audience calculation.
 
 Security
 ========

--- a/examples/custom-audience/index.js
+++ b/examples/custom-audience/index.js
@@ -24,7 +24,11 @@ const sst = new sstsdk(websiteID, overrides);
 function cookieJar(req, res) {
     return {
         get: (name) => req.cookies[name],
-        set: (name, value) => res.cookie(name, value),
+        set: (name, value, expiresInDays) => {
+            const expiresInMillis = expiresInDays * 24 * 3600 * 1000;
+            const expires = new Date(Date.now() + expiresInMillis);
+            res.cookie(name, value, { expires, domain: 'localhost' });
+        },
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@symplify-conversion/sst-sdk-nodejs",
-  "version": "0.4.1-dev",
+  "version": "0.5.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@symplify-conversion/sst-sdk-nodejs",
-      "version": "0.4.1-dev",
+      "version": "0.5.0-dev",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@symplify-conversion/sst-sdk-nodejs",
-  "version": "0.4.1-dev",
+  "version": "0.5.0-dev",
   "description": "This is the Node.js implementation of the Symplify Server-Side Testing SDK.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/audience.ts
+++ b/src/audience.ts
@@ -12,6 +12,8 @@ import {
     parse,
     PrimitiveFn,
     RulesEngineError,
+    TracedList,
+    traceEval,
 } from "./rules-engine";
 
 type AudienceError = RulesEngineError;
@@ -55,6 +57,20 @@ export class Audience {
 
         if (!(typeof result == "boolean")) {
             return { message: `audience result was not boolean (${result})` };
+        }
+
+        return result;
+    }
+
+    /**
+     * trace interprets the rules in the given environment, and annotates the
+     * rules with partial values.
+     */
+    trace(env: Environment): TracedList | AudienceError {
+        const result = traceEval(this.rules, env, primitives);
+
+        if (!Array.isArray(result)) {
+            return { message: `audience trace failed (expected a list, but got ${result})` };
         }
 
         return result;

--- a/src/audience.ts
+++ b/src/audience.ts
@@ -75,7 +75,7 @@ function numberFun(a: Atom, b: Atom, op: (x: number, y: number) => Atom): Audien
     return op(a, b);
 }
 
-const primitives: Record<string, PrimitiveFn> = {
+export const primitives: Record<string, PrimitiveFn> = {
     // boolean operations
     not: (args: Atom[]) => {
         const [arg] = args;

--- a/src/client.ts
+++ b/src/client.ts
@@ -232,7 +232,7 @@ function handlePreview(
 
     const audienceTrace = project.audience?.trace({ attributes: audienceAttributes });
     if (audienceTrace) {
-        cookies.set("sg_audience_trace", JSON.stringify(audienceTrace), 0);
+        cookies.set("sg_audience_trace", JSON.stringify(audienceTrace), 1);
     }
 
     if (!doesAudienceApply(project, audienceAttributes, log)) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { CookieJar, visitorHasOptedIn, WebsiteData } from "./cookies";
+import { CookieJar, CookieWriter, visitorHasOptedIn, WebsiteData } from "./cookies";
 import { httpsGET } from "./http";
 import { Logger, NullLogger } from "./logger";
 import {
@@ -7,9 +7,12 @@ import {
     doesAudienceApply,
     findProjectWithName,
     findVariationForVisitor,
+    findVariationWithID,
     parseConfigJSON,
     PrivacyMode,
+    ProjectConfig,
     SymplifyConfig,
+    VariationConfig,
 } from "./project";
 import { ensureVisitorID } from "./visitor";
 
@@ -117,54 +120,47 @@ export class SymplifySDK {
             return null;
         }
 
+        const visitorID = ensureVisitorID(siteData, this.idGenerator);
+        if (!visitorID) {
+            this.log.error("could not get or generate a visitor ID");
+            return null;
+        }
+
         const project = findProjectWithName(this.config.latest, projectName);
         if (!project) {
             this.log.error(`findVariation: unknown project: ${projectName}`);
             return null;
         }
 
+        // 1. if previewing a project, handle and return early
+
+        if (siteData.getPreviewData() !== null) {
+            return handlePreview(siteData, project, cookies, audienceAttributes, this.log);
+        }
+
         if (project.state !== "active") {
             return null;
         }
 
-        const currAllocation = siteData.getAllocation(project);
+        // 2. if we already have an allocation from a previous visit, use that and return early
 
-        switch (currAllocation) {
-            case undefined:
-                // no allocation data
-                break;
-            case null:
-                // explicit null allocation
-                return null;
-            default:
-                // variation allocation
-                return currAllocation.name;
+        if (siteData.getAllocation(project) !== undefined) {
+            const cookieAllocation = siteData.getAllocation(project);
+            return cookieAllocation ? cookieAllocation.name : null;
         }
 
-        // if we have not returned yet, we are about to make a decision about the visitor's allocation
+        // 3. no preview or variation from before: let's make a decision about the visitor's allocation
 
         if (!doesAudienceApply(project, audienceAttributes, this.log)) {
             // if the audience does not apply, we will not persist any variation so don't need to do anything else here
             return null;
         }
 
-        const visID = ensureVisitorID(siteData, this.idGenerator);
-        if (!visID) {
-            this.log.error("could not get or generate a visitor ID");
-            return null;
-        }
-
-        const variation = findVariationForVisitor(project, visID);
-
-        if (variation) {
-            siteData.rememberAllocation(project, variation);
-        } else {
-            siteData.rememberNullAllocation(project);
-        }
+        const variation = allocateVariation(siteData, project, visitorID);
 
         siteData.save(cookies);
 
-        return variation ? variation.name : null;
+        return variation?.name || null;
     }
 
     configURL(): string {
@@ -197,6 +193,62 @@ export class SymplifySDK {
     async fetchConfig(): Promise<SymplifyConfig> {
         return await this.httpGET(this.configURL()).then(parseConfigJSON);
     }
+}
+
+/**
+ * Calculate the variation allocation for the given visitor ID,
+ * save the allocation in the site data.
+ */
+function allocateVariation(
+    siteData: WebsiteData,
+    project: ProjectConfig,
+    visitorID: string,
+): VariationConfig | null {
+    const variation = findVariationForVisitor(project, visitorID);
+
+    if (variation) {
+        siteData.rememberAllocation(project, variation);
+    } else {
+        siteData.rememberNullAllocation(project);
+    }
+
+    return variation;
+}
+
+/**
+ * Get the preview variation name for the given visitor ID,
+ * update cookies if needed.
+ */
+function handlePreview(
+    siteData: WebsiteData,
+    project: ProjectConfig,
+    cookies: CookieWriter,
+    audienceAttributes: AudienceAttributes,
+    log: Logger,
+): string | null {
+    // While this function looks quite similar to allocating a variation
+    // normally, there are other things we handle here, such as tracing the
+    // audience evaluation.
+
+    const audienceTrace = project.audience?.trace({ attributes: audienceAttributes });
+    if (audienceTrace) {
+        cookies.set("sg_audience_trace", JSON.stringify(audienceTrace), 0);
+    }
+
+    if (!doesAudienceApply(project, audienceAttributes, log)) {
+        return null;
+    }
+
+    const variationID = siteData.getPreviewData()?.variationID;
+    const variation = variationID ? findVariationWithID(project, variationID) : null;
+
+    if (variation) {
+        siteData.rememberAllocation(project, variation);
+    }
+
+    siteData.save(cookies);
+
+    return variation?.name || null;
 }
 
 /**

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -20,6 +20,14 @@ export type CookieWriter = {
 
 export type CookieJar = CookieReader & CookieWriter;
 
+/**
+ * PreviewData is used by the SDK when users are previewing tests without activating them.
+ */
+export type PreviewData = {
+    projectID: number;
+    variationID: number;
+};
+
 export class JSONCookieCodec {
     underlying: CookieJar;
 
@@ -43,6 +51,8 @@ export class JSONCookieCodec {
 const JSON_COOKIE_NAME = "sg_cookies";
 const JSON_COOKIE_VERSION_KEY = "_g";
 const JSON_COOKIE_VISITOR_ID_KEY = "visid";
+const JSON_COOKIE_PREVIEW_PROJECT_KEY = "pmr";
+const JSON_COOKIE_PREVIEW_VARIATION_KEY = "pmv";
 const SUPPORTED_JSON_COOKIE_VERSION = 1;
 
 /**
@@ -120,6 +130,26 @@ export class WebsiteData {
         }
 
         return undefined;
+    }
+
+    /**
+     * Get current preview config from the website data.
+     *
+     * @returns the current preview config if it exists, null otherwise
+     */
+    getPreviewData(): PreviewData | null {
+        const projectID = this.get(JSON_COOKIE_PREVIEW_PROJECT_KEY);
+        const variationID = this.get(JSON_COOKIE_PREVIEW_VARIATION_KEY);
+
+        if (typeof projectID !== "number") {
+            return null;
+        }
+
+        if (typeof variationID !== "number") {
+            return null;
+        }
+
+        return { projectID, variationID };
     }
 
     private get(key: string): unknown {

--- a/src/project.ts
+++ b/src/project.ts
@@ -36,6 +36,25 @@ export type VariationConfig = {
     state: ProjectState;
 };
 
+/**
+ * Look up the variation with the given ID in the given project.
+ */
+export function findVariationWithID(
+    project: ProjectConfig,
+    variationID: number,
+): VariationConfig | null {
+    for (const variation of project.variations) {
+        if (variation.id === variationID) {
+            return variation;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Look up the project with the given name, regardless of ID or active state.
+ */
 export function findProjectWithName(
     config: SymplifyConfig,
     projectName: string,
@@ -49,6 +68,11 @@ export function findProjectWithName(
     return null;
 }
 
+/**
+ * Allocate an active variation for the visitor in the given project.
+ *
+ * @returns null if the visitor ID is empty or the project or variation is not active
+ */
 export function findVariationForVisitor(
     project: ProjectConfig,
     visitorID: string,

--- a/test/audience.test.ts
+++ b/test/audience.test.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 
-import { Audience } from "../src/audience";
+import { Audience, primitives } from "../src/audience";
+import { traceEval } from "../src/rules-engine";
 
 describe("Audience validation", () => {
     const testData = JSON.parse(fs.readFileSync("test/audience_validation_spec.json").toString());
@@ -95,6 +96,27 @@ describe("Audience attributes compatibility tests", () => {
                     }
                 });
             }
+        });
+    }
+});
+
+/**
+ * These test cases are defined in JSON to enable portable repeatable testing for multiple SDKs.
+ *
+ * Part of the audience test suite because of the `primitives` dependency.
+ */
+describe("Rules expression tracing compatibility tests", () => {
+    const testData = JSON.parse(fs.readFileSync("test/audience_tracing_spec.json").toString());
+
+    for (const { test_name, skip, rules, attributes, expect_trace } of testData) {
+        if (skip) {
+            console.log(`skipping test '${test_name}' (because ${skip})`);
+            continue;
+        }
+
+        test(test_name, () => {
+            const actualTrace = traceEval(rules, { attributes }, primitives);
+            expect(actualTrace).toStrictEqual(expect_trace);
         });
     }
 });

--- a/test/audience_tracing_spec.json
+++ b/test/audience_tracing_spec.json
@@ -1,0 +1,67 @@
+[
+  {
+    "test_name": "true number compare",
+    "rules": ["any", [">", ["number-attribute", "points"], 100]],
+    "attributes": { "points": 1000 },
+    "expect_trace": [
+      { "call": "any", "result": true },
+      [
+        { "call": ">", "result": true },
+        [{ "call": "number-attribute", "result": 1000 }, "points"],
+        100
+      ]
+    ]
+  },
+  {
+    "test_name": "false string compare",
+    "rules": ["any", ["contains", ["string-attribute", "foo"], "bar"]],
+    "attributes": { "foo": "baz" },
+    "expect_trace": [
+      { "call": "any", "result": false },
+      [
+        { "call": "contains", "result": false },
+        [{ "call": "string-attribute", "result": "baz" }, "foo"],
+        "bar"
+      ]
+    ]
+  },
+  {
+    "test_name": "errors bubble up",
+    "rules": ["any", [">", ["number-attribute", "points"], 100]],
+    "attributes": {},
+    "expect_trace": [
+      { "call": "any", "result": { "message": "'points' is not a number" } },
+      [
+        { "call": ">", "result": { "message": "'points' is not a number" } },
+        [
+          {
+            "call": "number-attribute",
+            "result": { "message": "'points' is not a number" }
+          },
+          "points"
+        ],
+        100
+      ]
+    ]
+  },
+  {
+    "test_name": "bool bonanza",
+    "rules": [
+      "any",
+      ["bool-attribute", "no"],
+      ["any", ["bool-attribute", "yes"]],
+      ["all", ["bool-attribute", "yes"], ["any"]]
+    ],
+    "attributes": { "yes": true, "no": false },
+    "expect_trace": [
+      { "call": "any", "result": true },
+      [{ "call": "bool-attribute", "result": false }, "no"],
+      [{ "call": "any", "result": true }, [{ "call": "bool-attribute", "result": true }, "yes"]],
+      [
+        { "call": "all", "result": false },
+        [{ "call": "bool-attribute", "result": true }, "yes"],
+        [{ "call": "any", "result": false }]
+      ]
+    ]
+  }
+]

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -41,6 +41,11 @@ describe("SymplifySDK client", () => {
                 }
             }
 
+            const checkExtraCookieValues = t.expect_extra_cookies || {};
+            for (const [name, value] of Object.entries(checkExtraCookieValues)) {
+                expect(cookies.get(name)).toStrictEqual(value);
+            }
+
             const reVariation = new RegExp(t.expect_variation_match);
             expect(variation || "null").toMatch(reVariation);
         });

--- a/test/cookies.test.ts
+++ b/test/cookies.test.ts
@@ -88,4 +88,59 @@ describe("WebsiteData", () => {
         expect(data.getVisitorID()).toBe("goober%22");
         expect(data.getAllocation(testProject)).toStrictEqual(testVar);
     });
+
+    test("handles nonexistent preview data", () => {
+        const testSiteID = "4711";
+        const cookieData = {
+            [testSiteID]: {
+                "1337": [42],
+                "1337_ch": 1,
+                aud_p: [1337],
+                visid: "goober%22",
+            },
+            _g: 1,
+        };
+
+        const cookies = makeCookieJar();
+        cookies.set("sg_cookies", JSON.stringify(cookieData), 1);
+        const data = new WebsiteData(testSiteID, cookies);
+
+        expect(data.getPreviewData()).toBe(null);
+    });
+
+    test("handles legacy preview data", () => {
+        const testSiteID = "4711";
+        const cookieData = {
+            [testSiteID]: {
+                pmr: 9999, // legacy data, for sst we need the pmv property as well
+            },
+            _g: 1,
+        };
+
+        const cookies = makeCookieJar();
+        cookies.set("sg_cookies", JSON.stringify(cookieData), 1);
+        const data = new WebsiteData(testSiteID, cookies);
+
+        expect(data.getPreviewData()).toBe(null);
+    });
+
+    test("can get preview data", () => {
+        const testSiteID = "4711";
+        const cookieData = {
+            [testSiteID]: {
+                pmr: 9999,
+                pmv: 99991,
+            },
+            _g: 1,
+        };
+
+        const cookies = makeCookieJar();
+        cookies.set("sg_cookies", JSON.stringify(cookieData), 1);
+        const data = new WebsiteData(testSiteID, cookies);
+
+        expect(data.getPreviewData()).toStrictEqual({
+            projectID: 9999,
+            variationID: 99991,
+        });
+    });
 });

--- a/test/test_cases.json
+++ b/test/test_cases.json
@@ -172,7 +172,7 @@
     "website_id": "10001",
     "test_project_name": "custom audience",
     "audience_attributes": {
-        "foo": "baz"
+      "foo": "baz"
     },
     "expect_variation_match": null
   },
@@ -182,8 +182,73 @@
     "website_id": "10001",
     "test_project_name": "custom audience",
     "audience_attributes": {
-        "foo": "bar"
+      "foo": "bar"
     },
     "expect_variation_match": "Original"
+  },
+  {
+    "test_name": "preview overrides allocation",
+    "sdk_config": "sdk_config.json",
+    "website_id": "10001",
+    "cookies": {
+      "sg_cookies": "{%2210001%22:{%22visid%22:%22foobar%22%2C%22pmr%22:1001%2C%22pmv%22:10013}%2C%22_g%22:1}"
+    },
+    "test_project_name": "test project",
+    "expect_variation_match": "active variation 2"
+  },
+  {
+    "test_name": "preview overrides paused state",
+    "sdk_config": "sdk_config.json",
+    "website_id": "10001",
+    "cookies": {
+      "sg_cookies": "{%2210001%22:{%22visid%22:%22foobar%22%2C%22pmr%22:1001%2C%22pmv%22:10012}%2C%22_g%22:1}"
+    },
+    "test_project_name": "test project",
+    "expect_variation_match": "paused variation 1"
+  },
+  {
+    "test_name": "preview allocation is persisted",
+    "sdk_config": "sdk_config.json",
+    "website_id": "10001",
+    "cookies": {
+      "sg_cookies": "{%2210001%22:{%22visid%22:%22foobar%22%2C%22pmr%22:1001%2C%22pmv%22:10012}%2C%22_g%22:1}"
+    },
+    "test_project_name": "test project",
+    "expect_variation_match": "paused variation 1",
+    "expect_sg_cookie_properties_match": {
+      "10001/1001_ch": 1,
+      "10001/1001": [10012],
+      "10001/aud_p": [1001]
+    }
+  },
+  {
+    "test_name": "preview shows true audience trace",
+    "sdk_config": "sdk_config.json",
+    "website_id": "10001",
+    "test_project_name": "custom audience",
+    "audience_attributes": {
+      "foo": "bar"
+    },
+    "cookies": {
+      "sg_cookies": "{%2210001%22:{%22visid%22:%22foobar%22%2C%22pmr%22:1005%2C%22pmv%22:10051}%2C%22_g%22:1}"
+    },
+    "expect_extra_cookies": {
+      "sg_audience_trace": "[{\"call\":\"equals\",\"result\":true},[{\"call\":\"string-attribute\",\"result\":\"bar\"},\"foo\"],\"bar\"]"
+    }
+  },
+  {
+    "test_name": "preview shows false audience trace",
+    "sdk_config": "sdk_config.json",
+    "website_id": "10001",
+    "test_project_name": "custom audience",
+    "audience_attributes": {
+      "foo": "baz"
+    },
+    "cookies": {
+      "sg_cookies": "{%2210001%22:{%22visid%22:%22foobar%22%2C%22pmr%22:1005%2C%22pmv%22:10051}%2C%22_g%22:1}"
+    },
+    "expect_extra_cookies": {
+      "sg_audience_trace": "[{\"call\":\"equals\",\"result\":false},[{\"call\":\"string-attribute\",\"result\":\"baz\"},\"foo\"],\"bar\"]"
+    }
   }
 ]


### PR DESCRIPTION
Why?
====

Before activating a project for real visitors, one might want to preview it to verify that

* the audience is setup as expected
* the site looks as expected for each variation

Given that staging and production environments can differ, enabling this kind of testing in production is important.

Solution
======

Add support for overriding the project used via preview settings in the cookie (the simplest way for users to communicate with the server-side SDK). The cookie allows projects to be activated in a "preview mode", meaning:

* the audience rules can be traced (debugging your expressions)
* the normal variation allocation is overridden
* no goals will be tracked

See docs/Previewing.md for details.

Testing
=====

New data driven JSON test cases were added for the preview feature.

I tested the example site `custom-audience` through curl to see the preview setting and audience tracing work end-to-end.

I also tested in a browser, manually poking the cookie to enable preview. Here I noticed the cookie is not persisted properly (due to me setting expires to "now").

TODO
====

- [x] resolve the expires issue for the sg_audience_trace cookie