### PR TITLE
Add reference to sst-documentation repository for cookie information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 cookies.curl.txt
 benchmark/results
 test/*.json
+/.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- add reference in documentation to [SST-documentation](https://github.com/SymplifyConversion/sst-documentation/) 
+repository regarding cookie usage and setup
+
 ## [0.5.1] - 2022-10-04
 
 ### Changed
@@ -57,7 +61,8 @@ It is now located in [SST-documentations docs folder](https://github.com/Symplif
   - injectable log delegate
   - injectable http fetch delegate
 
-[Unreleased]: https://github.com/SymplifyConversion/sst-sdk-nodejs/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/SymplifyConversion/sst-sdk-nodejs/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/SymplifyConversion/sst-sdk-nodejs/releases/tag/v0.5.1
 [0.5.0]: https://github.com/SymplifyConversion/sst-sdk-nodejs/releases/tag/v0.5.0
 [0.4.0]: https://github.com/SymplifyConversion/sst-sdk-nodejs/releases/tag/v0.4.0
 [0.3.0]: https://github.com/SymplifyConversion/sst-sdk-nodejs/releases/tag/v0.3.0

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ function getDiscounts(req, res) {
 
 ### Cookie integration
 
+See [SST-documentation](https://github.com/SymplifyConversion/sst-documentation/) repository for general cookie setup information.
+
 To ensure visitors get the same variation consistently, the SDK needs to
 read and write cookies. Each web framework has a different way to get this
 functionality. This function `cookieJar` is one way to make an adapter for


### PR DESCRIPTION
### Changed
- add reference in documentation to [SST-documentation](https://github.com/SymplifyConversion/sst-documentation/) repository regarding cookie usage and setup